### PR TITLE
Support coffee-script in requires

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
       "url": "http://www.opensource.org/licenses/mit-license.php"
     }
   ],
+  "dependencies": {
+    "coffee-script": "1.4.x"
+  },
   "devDependencies": {
     "mocha": "1.3.x",
     "should": "0.6.x",

--- a/proxyquire.js
+++ b/proxyquire.js
@@ -4,6 +4,7 @@
 var path            =  require('path')
   , fs              =  require('fs')
   , util            =  require('util')
+  , coffee          =  require('coffee-script')
   , existsSync      =  fs.existsSync || path.existsSync // support node <=0.6
   , registeredStubs =  { }
   , stubkey         =  0
@@ -213,6 +214,7 @@ function resolve (mdl, test__dirname, stubs) {
     , resolvedMdl    =  require.resolve(mdlPath)
     , resolvedFile   =  findFile(resolvedMdl)
     , originalCode   =  fs.readFileSync(resolvedFile)
+    , compiledCode   =  coffee.compile(originalCode.toString())
     , mdlProxyFile   =  path.basename(resolvedFile) + '@' + (stubkey++).toString()
     , resolvedProxy  =  path.join(tmpDir, normalizeExtension(mdlProxyFile))
     // all code will be written on one line, prepended to whatever was on first line to maintain linenos
@@ -224,7 +226,7 @@ function resolve (mdl, test__dirname, stubs) {
         ,   '.require("' , escapeBackslashes(__filename), '")'
         ,   '._require(mdl, "' + escapeBackslashes(resolvedProxy) + '", __dirname); '
         , '} '
-        , originalCode 
+        , compiledCode 
         ].join('')
     , dependency
     ;


### PR DESCRIPTION
I'm not sure the best way to test this, or if there's a way to add this support without requiring having the module require coffee-script, but this works as a quick proof of concept if it's a feature you'd be interested in adding.
