### PR TITLE
Support removing packages by stubbing to null.

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,33 @@ proxyquire.callThru();
 var foo2 = proxyquire('./foo', stubs);
 ```
 
+## Using proxyquire to remove modules
+
+Some libraries may behave differently in the presence of absence of a
+package, for example:
+
+```javascript
+var cluster;
+try {
+  cluster = require('cluster');
+} catch(e) {
+  // cluster module is not present.
+  cluster = null
+}
+if (cluster) {
+  /// Then provide some functionality on a cluster-aware version of node.js.
+} else {
+  // How do we exercise this path on a moern node.js that has cluster built-in?
+}
+```
+
+To exercise this type of code, proxyquire can remove a package. Just
+set the stub for the specified package to null:
+
+```javascript
+var foo = proxyquire('./foo', { cluster: null });
+```
+
 ## Forcing proxyquire to reload modules
 
 In most situations it is fine to have proxyquire behave exactly like nodejs `require`, i.e. modules that are loaded once

--- a/lib/proxyquire.js
+++ b/lib/proxyquire.js
@@ -117,6 +117,8 @@ Proxyquire.prototype.load = function (request, stubs) {
 
   // Find out if any of the passed stubs are global overrides
   for (var key in stubs) {
+    if (stubs[key] === null) continue;
+
     if (stubs[key].hasOwnProperty('@global')) {
       this._containsGlobal = true;
     }
@@ -138,6 +140,13 @@ Proxyquire.prototype._require = function(module, stubs, path) {
 
   if (stubs.hasOwnProperty(path)) {
     var stub = stubs[path];
+
+    if (stub === null) {
+      // Mimic the module-not-found exception thrown by node.js.
+      var notfound = new Error("Cannot find module '" +  path + "'");
+      notfound.code = 'MODULE_NOT_FOUND';
+      throw notfound;
+    }
 
     if (stub.hasOwnProperty('@noCallThru') ? !stub['@noCallThru'] : !this._noCallThru) {
       fillMissingKeys(stub, Module._load(path, module));

--- a/test/proxyquire-remove.js
+++ b/test/proxyquire-remove.js
@@ -1,0 +1,24 @@
+'use strict';
+/*jshint asi:true*/
+/*global describe, before, beforeEach, it */
+
+var assert = require('assert')
+  , proxyquire = require('..')
+  , path = require('path')
+  , fooPath = path.join(__dirname, './samples/foo.js')
+
+describe('When resolving foo that requires nulled file package', function () {
+  it('throws an error', function () {
+    assert.throws(function () {
+      proxyquire(fooPath, { path: null })
+    })
+  })
+})
+
+describe('When resolving foo that optionally requires nulled crypto package', function () {
+  it('catches when resolving crypto', function () {
+    var foo = proxyquire(fooPath, { crypto: null })
+    assert.equal(foo.bigCrypto(), 'caught');
+  })
+})
+

--- a/test/samples/foo.js
+++ b/test/samples/foo.js
@@ -1,11 +1,15 @@
 var stats = require('./stats')
   , bar = require('./bar')
   , path = require('path')
+  , crypto
   ;
+
+// Require if present.
+try { crypto = require('crypto'); } catch (e) { crypto = 'caught'; }
 
 stats.incFooRequires();
 
-function bigBar () { 
+function bigBar () {
   // inline require
   return require('./bar').bar().toUpperCase();
 }
@@ -23,10 +27,15 @@ function bigBas (file) {
   return path.basename(file).toUpperCase();
 }
 
+function bigCrypto () {
+  return crypto;
+}
+
 module.exports = {
     bigBar: bigBar
   , bigRab: bigRab
   , bigExt: bigExt
   , bigBas: bigBas
+  , bigCrypto: bigCrypto
   , state: ''
 };


### PR DESCRIPTION
This change is motivated by tests that need to check behavior when require('crypto') fails.

With this change, proxyquire can remove packages by supplying null as the stub.

<pre>
proxyquire('tested', { crypto: null })
</pre>


The above will throw an error (same as Node's module-not-found exception) when tested.js tries to require('crypto').
