### PR TITLE
adds support for stubbing non-object imports (issue #46)

### DIFF
--- a/lib/proxyquire.js
+++ b/lib/proxyquire.js
@@ -9,10 +9,12 @@ var path = require('path')
   ;
 
 function fillMissingKeys(mdl, original) {
-  Object.keys(original).forEach(function (key) {
-    if (!mdl[key])  mdl[key] = original[key];
-  });
-
+  // do not fill in keys on primitives (ES5)
+  if (is.Object(original) || is.Function(original)) {
+      Object.keys(original).forEach(function (key) {
+        if (!mdl[key])  mdl[key] = original[key];
+      });
+  }
   return mdl;
 }
 

--- a/test/proxyquire-non-object.js
+++ b/test/proxyquire-non-object.js
@@ -1,0 +1,69 @@
+/*jshint asi:true*/
+/*global describe, before, it */
+"use strict";
+
+var assert = require('assert')
+  , proxyquire = require('..')
+  , stats = require('./samples/stats')
+  ;
+
+describe('Given foo requires the boof, foonum and foobool modules and  boof is a string, foonum is a Number and foobool is a bool', function () {
+  var file = '/folder/test.ext'
+    , foo
+    , boofber = 'a_string'
+    , foonumber = 4
+    , fooboolber = false
+    ;
+
+  describe('When I resolve foo with boofber stub as boof.', function () {
+    before(function () {
+      stats.reset();
+      foo = proxyquire('./samples/foo', { './boof':boofber})
+    })
+
+    it('foo is required 1 times', function () {
+      assert.equal(stats.fooRequires(), 1);
+    })
+
+    describe('foo\'s boof is boofber', function () {
+      it('foo.boof == boofber', function () {
+        assert.equal(foo.boof, boofber);
+      })
+    })
+  })
+
+  describe('When I resolve foo with foonumber stub as foonum.', function () {
+    before(function () {
+      stats.reset();
+      foo = proxyquire('./samples/foo', { './foonum':foonumber})
+    })
+
+    it('foo is required 1 times', function () {
+      assert.equal(stats.fooRequires(), 1);
+    })
+
+    describe('foo\'s foonum is foonumber', function () {
+      it('foo.foonum == foonumber', function () {
+        assert.equal(foo.foonum, foonumber);
+      })
+    })
+  })
+
+  describe('When I resolve foo with fooboolber stub as foobool.', function () {
+    before(function () {
+      stats.reset();
+      foo = proxyquire('./samples/foo', { './foobool':fooboolber})
+    })
+
+    it('foo is required 1 times', function () {
+      assert.equal(stats.fooRequires(), 1);
+    })
+
+    describe('foo\'s foobool is fooboolber', function () {
+      it('foo.foobool == fooboolber', function () {
+        assert.equal(foo.foobool, fooboolber);
+      })
+    })
+  })
+
+})

--- a/test/samples/boof.js
+++ b/test/samples/boof.js
@@ -1,0 +1,1 @@
+module.exports = 'boof'

--- a/test/samples/foo.js
+++ b/test/samples/foo.js
@@ -1,5 +1,8 @@
 var stats = require('./stats')
   , bar = require('./bar')
+  , boof = require('./boof')
+  , foonum = require('./foonum')
+  , foobool = require('./foobool')
   , path = require('path')
   ;
 
@@ -28,5 +31,8 @@ module.exports = {
   , bigRab: bigRab
   , bigExt: bigExt
   , bigBas: bigBas
+  , boof: boof
+  , foonum: foonum
+  , foobool: foobool
   , state: ''
 };

--- a/test/samples/foobool.js
+++ b/test/samples/foobool.js
@@ -1,0 +1,1 @@
+module.exports = true

--- a/test/samples/foonum.js
+++ b/test/samples/foonum.js
@@ -1,0 +1,1 @@
+module.exports = 3


### PR DESCRIPTION
- proxyquire.js only fills in the missing keys of non-primitive types
- re issue #46
