### PR TITLE
Make require.extensions.js (and others) writable [atom-shell, io.js]

### DIFF
--- a/lib/proxyquire.js
+++ b/lib/proxyquire.js
@@ -238,6 +238,13 @@ Proxyquire.prototype._overrideExtensionHandlers = function(module, stubs) {
       originalExtensions[extension] = require.extensions[extension];
     }
 
+    // Try to make the extension handler writable if it's not
+    if (Object.getOwnPropertyDescriptor(require.extensions, extension).writable === false) {
+      Object.defineProperty(require.extensions, extension, {
+        writable: true
+      });
+    }
+
     // Override the default handler for the requested file extension
     require.extensions[extension] = function(module, filename) {
       // Override the require method for this module


### PR DESCRIPTION
Earlier today I updated our atom-shell based application to Atom Shell v0.21.1. They've moved the project to io.js, and our specs use Proxyquire. It appears that `require.extensions[extension]` cannot be overridden by default and I was getting the error:

```
TypeError: Cannot assign to read only property '.js' of #<Object>
  at /Users/bengotow/Desktop/dogwood/edgehill/node_modules/proxyquire/lib/proxyquire.js:242:35
  at Array.forEach (native)

```

I added a few lines to manually redefine the properties before trying to write to them. It fixed our issue, but I admit I have a very limited understanding of what has changed in require.