### PR TITLE
iojs fix

### DIFF
--- a/lib/proxyquire.js
+++ b/lib/proxyquire.js
@@ -12,6 +12,7 @@ function fillMissingKeys(mdl, original) {
   if (is.Object(original) || is.Function(original)) {
     // fill in keys for all objects
     Object.keys(original).forEach(function (key) {
+      if (mdl.hasOwnProperty(key) && !Object.getOwnPropertyDescriptor(mdl, key).writable) return;
       if (!mdl[key])  mdl[key] = original[key];
     });
   }

--- a/test/proxyquire.js
+++ b/test/proxyquire.js
@@ -189,4 +189,14 @@ describe('Given foo requires the bar and path modules and bar.bar() returns "bar
 })
 
 
+describe('When proxying core modules', function() {
 
+  it('prevents TypeErrors from being thrown', function() {
+    assert.doesNotThrow(function() {
+      proxyquire('./samples/coremodules', {
+        'fs': require('fs')
+      });
+    }, TypeError);
+  })
+
+})

--- a/test/samples/coremodules.js
+++ b/test/samples/coremodules.js
@@ -1,0 +1,3 @@
+module.exports = {
+  fs : require('fs')
+}


### PR DESCRIPTION
Fixes #51

> TypeError: Cannot assign to read only property 'F_OK' of #<Object>

This error was thrown while trying to overwrite the file system module object. In iojs [the properties `F_OK, R_OK, W_OK and X_OK` are defined as read only](https://github.com/iojs/io.js/blob/v1.4.2/lib/fs.js#L169-L173), so adding a property check was required to fix this issue.

Also please have a look at [`!mdl[key]`](https://github.com/thlorenz/proxyquire/blob/v1.3.1/lib/proxyquire.js#L15)... Shouldn't this be changed to `!(key in mdl)`? This was one of the reasons why this error occured, because of the value of `F_OK` (which is `0`), so this expression resulted into `true`. I've tried to change it, but one of the tests failed afterwards and I don't have the time investigating further...