### PR TITLE
Only fill module keys that are not defined

### DIFF
--- a/lib/proxyquire.js
+++ b/lib/proxyquire.js
@@ -12,7 +12,7 @@ function fillMissingKeys(mdl, original) {
   if (is.Object(original) || is.Function(original)) {
     // fill in keys for all objects
     Object.keys(original).forEach(function (key) {
-      if (typeof mdl[key] === 'undefined')  mdl[key] = original[key];
+      if (!(key in mdl))  mdl[key] = original[key];
     });
   }
   return mdl;

--- a/test/proxyquire.js
+++ b/test/proxyquire.js
@@ -66,8 +66,8 @@ describe('Given foo requires the bar and path modules and bar.bar() returns "bar
       describe('and then delete overrides of stubs after resolve', function () {
 
         beforeEach(function () {
-          barber.bar = undefined;
-          barber.rab = undefined;
+          delete barber.bar;
+          delete barber.rab;
         })
 
         it('reverts to original behavior when module is required inside function call', function () {


### PR DESCRIPTION
@thlorenz Continuing our discussion from 16f66f3f811cd615b8a1ff520a89e3fee6bad8db

This change actually specifically violates a test. Not sure whether it's worth changing even though using the `in` operator and forcing users to use `delete` is technically correct here. 