### PR TITLE
Use fill-keys to copy from original module

### DIFF
--- a/lib/proxyquire.js
+++ b/lib/proxyquire.js
@@ -6,17 +6,8 @@ var path = require('path')
   , ProxyquireError = require('./proxyquire-error')
   , is = require('./is')
   , assert = require('assert')
+  , fillMissingKeys = require('fill-keys')
   ;
-
-function fillMissingKeys(mdl, original) {
-  if (is.Object(original) || is.Function(original)) {
-    // fill in keys for all objects
-    Object.keys(original).forEach(function (key) {
-      if (!(key in mdl))  mdl[key] = original[key];
-    });
-  }
-  return mdl;
-}
 
 function validateArguments(request, stubs) {
   var msg = (function getMessage() {

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
     "mocha": "~1.18",
     "should": "~3.3",
     "sinon": "~1.9"
+  },
+  "dependencies": {
+    "fill-keys": "^1.0.0"
   }
 }


### PR DESCRIPTION
Makes key filling more consistent and predictable in addition to allowing pq and pqify to have identical behavior. Full description of the very small caveats is in the commit message.