### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,12 +22,7 @@
     "stub"
   ],
   "author": "Thorsten Lorenz",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/thlorenz/proxyquire/blob/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "devDependencies": {
     "mocha": "~1.18",
     "should": "~3.3",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/