### PR TITLE
Never assume objects have a prototype

### DIFF
--- a/lib/proxyquire.js
+++ b/lib/proxyquire.js
@@ -8,6 +8,7 @@ var path = require('path')
   , assert = require('assert')
   , fillMissingKeys = require('fill-keys')
   , moduleNotFoundError = require('module-not-found-error')
+  , hasOwnProperty = Object.prototype.hasOwnProperty
   ;
 
 function validateArguments(request, stubs) {
@@ -113,11 +114,11 @@ Proxyquire.prototype.load = function (request, stubs) {
   for (var key in stubs) {
     if (stubs[key] === null) continue;
 
-    if (stubs[key].hasOwnProperty('@global')) {
+    if (hasOwnProperty.call(stubs[key], '@global')) {
       this._containsGlobal = true;
     }
 
-    if (stubs[key].hasOwnProperty('@runtimeGlobal')) {
+    if (hasOwnProperty.call(stubs[key], '@runtimeGlobal')) {
       this._containsGlobal = true;
       this._containsRuntimeGlobal = true;
     }
@@ -132,7 +133,7 @@ Proxyquire.prototype._require = function(module, stubs, path) {
   assert(typeof path === 'string', 'path must be a string');
   assert(path, 'missing path');
 
-  if (stubs.hasOwnProperty(path)) {
+  if (hasOwnProperty.call(stubs, path)) {
     var stub = stubs[path];
 
     if (stub === null) {
@@ -140,12 +141,12 @@ Proxyquire.prototype._require = function(module, stubs, path) {
       throw moduleNotFoundError(path);
     }
 
-    if (stub.hasOwnProperty('@noCallThru') ? !stub['@noCallThru'] : !this._noCallThru) {
+    if (hasOwnProperty.call(stub, '@noCallThru') ? !stub['@noCallThru'] : !this._noCallThru) {
       fillMissingKeys(stub, Module._load(path, module));
     }
 
     // We are top level or this stub is marked as global
-    if (module.parent == this._parent || stub.hasOwnProperty('@global') || stub.hasOwnProperty('@runtimeGlobal')) {
+    if (module.parent == this._parent || hasOwnProperty.call(stub, '@global') || hasOwnProperty.call(stub, '@runtimeGlobal')) {
       return stub;
     }
   }


### PR DESCRIPTION
Allows stubs to be created with `Object.create(null)`. While incredibly unlike to affect anyone, I think it doesn't hurt to make it a rule to call `hasOwnProperty` this way for untrusted objects.