### PR TITLE
Throw when a stub is undefined to help prevent user error

### DIFF
--- a/lib/proxyquire.js
+++ b/lib/proxyquire.js
@@ -112,13 +112,19 @@ Proxyquire.prototype.load = function (request, stubs) {
 
   // Find out if any of the passed stubs are global overrides
   for (var key in stubs) {
-    if (stubs[key] === null) continue;
+    var stub = stubs[key];
 
-    if (hasOwnProperty.call(stubs[key], '@global')) {
+    if (stub === null) continue;
+
+    if (typeof stub === 'undefined') {
+      throw new ProxyquireError('Invalid stub: "' + key + '" cannot be undefined');
+    }
+
+    if (hasOwnProperty.call(stub, '@global')) {
       this._containsGlobal = true;
     }
 
-    if (hasOwnProperty.call(stubs[key], '@runtimeGlobal')) {
+    if (hasOwnProperty.call(stub, '@runtimeGlobal')) {
       this._containsGlobal = true;
       this._containsRuntimeGlobal = true;
     }

--- a/test/proxyquire-argumentvalidation.js
+++ b/test/proxyquire-argumentvalidation.js
@@ -59,4 +59,16 @@ describe('Illegal parameters to resolve give meaningful errors', function () {
       throws(act,  /invalid argument: "stubs".+needs to be an object/i);
     })
   })
+
+  describe('when I pass an undefined stub', function () {
+    function act () {
+      proxyquire('./samples/foo', {
+        myStub: undefined
+      })
+    }
+
+    it('throws an exception with the stub key', function () {
+      throws(act, /Invalid stub: "myStub" cannot be undefined/)
+    })
+  })
 })


### PR DESCRIPTION
Closes #73