### PR TITLE
package: update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "stub"
   ],
   "author": "Thorsten Lorenz",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MIT",
   "devDependencies": {
     "mocha": "~1.18",
     "should": "~3.3",


### PR DESCRIPTION
It seems like the license you specified in the `LICENSE` file was the MIT license. This update specifies a [SPDX standard license](http://spdx.org/). This is now the guideline from npm.

Please see [the npm1K project](https://npm1k.org) for more information :)