### PR TITLE
Only remove modules that are not *.node from the cache

### DIFF
--- a/lib/proxyquire.js
+++ b/lib/proxyquire.js
@@ -202,7 +202,17 @@ Proxyquire.prototype._disableCache = function(module, path) {
 
 Proxyquire.prototype._disableGlobalCache = function() {
   var cache = require.cache;
-  require.cache = Module._cache = {};
+  var dotNodeOnlyCache = require.cache = Module._cache = {};
+
+  for (var id in cache) {
+    // only keeo modules that are native (ie: `.node` files)
+    // otherwise, it would throw this on second require :
+    // => "Error: Module did not self-register."
+    // see https://github.com/nodejs/node/issues/5016
+    if (id.match(/.node$/)) {
+      dotNodeOnlyCache[id] = cache[id];
+    }
+  }
 
   // Return a function that will undo what we just did
   return function() {


### PR DESCRIPTION
Removing a *.node module from the cache and requiring it a 2nd time causes an Error :
Error: Module did not self-register.

See https://github.com/nodejs/node/issues/5016

Fixes #108.
