### PR TITLE
Add test to catch issue with preserveCache not preserving correctly

### DIFF
--- a/test/proxyquire-cache.js
+++ b/test/proxyquire-cache.js
@@ -21,6 +21,17 @@ describe("Proxyquire", function() {
   });
 
   describe('preserveCache()', function() {
+
+    it('should return a cache of the module after first proxyquire call', function() {
+        var proxyquire = require('..').preserveCache();
+        var count1 = proxyquire('./samples/count', {});
+        var count2 = proxyquire('./samples/count', {});
+        var count3 = proxyquire('./samples/count', {});
+        assert.equal(count1(), 1);
+        assert.equal(count2(), 2);
+        assert.equal(count3(), 3);
+    });
+
     it('returns a reference to itself, so it can be chained', function() {
       var proxyquire = require('..');
       assert.equal(proxyquire.preserveCache(), proxyquire);

--- a/test/samples/count.js
+++ b/test/samples/count.js
@@ -1,0 +1,4 @@
+var count = 0;
+module.exports = function() {
+    return ++count;
+};


### PR DESCRIPTION
This PR adds an additional test to catch an issue with preserveCache not preserving the cache correctly.  Currently this test fails as the bug has not been fixed.

This PR relates to #133 