### PR TITLE
Update mocha dependency to ~3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "Thorsten Lorenz",
   "license": "MIT",
   "devDependencies": {
-    "mocha": "~1.18",
+    "mocha": "~3.1",
     "should": "~3.3",
     "sinon": "~1.9"
   },


### PR DESCRIPTION
This prevents deprecated messages on a number of dependencies of the previous
mocha version - 1.18.x. Should result in a minor version bump due to mocha's
increased minimum node version dependency - 0.10.x vs. 0.4.x