### PR TITLE
Add nameResolver feature

### DIFF
--- a/lib/proxyquire.js
+++ b/lib/proxyquire.js
@@ -25,7 +25,7 @@ function validateArguments(request, stubs) {
       return 'Invalid argument: "request". Needs to be a requirable string that is the module to load.';
 
     if (!is.Object(stubs))
-      return 'Invalid argument: "stubs". Needs to be an object containing overrides e.g., {"path": { extname: function() { ... } } }.';
+      return 'Invalid argument: "stubs". Needs to be an object containing overrides e.g., {"path": { extname: function () { ... } } }.';
   })();
 
   if (msg) throw new ProxyquireError(msg);
@@ -112,7 +112,7 @@ Proxyquire.prototype.callThru = function () {
  * @private
  * @return {object} The proxyquire function to allow chaining
  */
-Proxyquire.prototype.noPreserveCache = function () {
+Proxyquire.prototype.noPreserveCache = function() {
   this._preserveCache = false;
   return this.fn;
 };
@@ -125,7 +125,7 @@ Proxyquire.prototype.noPreserveCache = function () {
  * @private
  * @return {object} The proxyquire function to allow chaining
  */
-Proxyquire.prototype.preserveCache = function () {
+Proxyquire.prototype.preserveCache = function() {
   this._preserveCache = true;
   return this.fn;
 };
@@ -133,7 +133,7 @@ Proxyquire.prototype.preserveCache = function () {
 /**
  * Loads a module using the given stubs instead of their normally resolved required modules.
  * @param request The requirable module path to load.
- * @param stubs The stubs to use. e.g., { "path": { extname: function() { ... } } }
+ * @param stubs The stubs to use. e.g., { "path": { extname: function () { ... } } }
  * @return {*} A newly resolved module with the given stubs.
  */
 Proxyquire.prototype.load = function (request, stubs) {
@@ -164,7 +164,7 @@ Proxyquire.prototype.load = function (request, stubs) {
 };
 
 // This replaces a module's require function
-Proxyquire.prototype._require = function (module, stubs, path) {
+Proxyquire.prototype._require = function(module, stubs, path) {
   assert(typeof path === 'string', 'path must be a string');
   assert(path, 'missing path');
 
@@ -196,7 +196,7 @@ Proxyquire.prototype._require = function (module, stubs, path) {
   }
 };
 
-Proxyquire.prototype._withoutCache = function (module, stubs, path, func) {
+Proxyquire.prototype._withoutCache = function(module, stubs, path, func) {
   // Temporarily disable the cache - either per-module or globally if we have global stubs
   var restoreCache = this._disableCache(module, path);
 
@@ -219,8 +219,7 @@ Proxyquire.prototype._withoutCache = function (module, stubs, path, func) {
             extensions: Object.keys(require.extensions),
             paths: Module.globalPaths
           })
-        } catch (_) {
-        }
+        } catch (_) {}
       });
       var ids = [id].concat(stubIds.filter(Boolean));
 
@@ -234,7 +233,7 @@ Proxyquire.prototype._withoutCache = function (module, stubs, path, func) {
   }
 };
 
-Proxyquire.prototype._disableCache = function (module, path) {
+Proxyquire.prototype._disableCache = function(module, path) {
   if (this._containsGlobal) {
     // empty the require cache because if we are stubbing C but requiring A,
     // and if A requires B and B requires C, then B and C might be cached already
@@ -246,17 +245,17 @@ Proxyquire.prototype._disableCache = function (module, path) {
   return this._disableModuleCache(path, module);
 };
 
-Proxyquire.prototype._disableGlobalCache = function () {
+Proxyquire.prototype._disableGlobalCache = function() {
   var cache = require.cache;
   require.cache = Module._cache = {};
 
   // Return a function that will undo what we just did
-  return function () {
+  return function() {
     require.cache = Module._cache = cache;
   };
 };
 
-Proxyquire.prototype._disableModuleCache = function (path, module) {
+Proxyquire.prototype._disableModuleCache = function(path, module) {
   // Find the ID (location) of the SUT, relative to the parent
   var id = Module._resolveFilename(path, module);
 
@@ -264,25 +263,25 @@ Proxyquire.prototype._disableModuleCache = function (path, module) {
   delete Module._cache[id];
 
   // Return a function that will undo what we just did
-  return function () {
+  return function() {
     if (cached) {
       Module._cache[id] = cached;
     }
   };
 };
 
-Proxyquire.prototype._overrideExtensionHandlers = function (module, stubs) {
+Proxyquire.prototype._overrideExtensionHandlers = function(module, stubs) {
   var originalExtensions = {};
   var self = this;
 
-  Object.keys(require.extensions).forEach(function (extension) {
+  Object.keys(require.extensions).forEach(function(extension) {
     // Store the original so we can restore it later
     if (!originalExtensions[extension]) {
       originalExtensions[extension] = require.extensions[extension];
     }
 
     // Override the default handler for the requested file extension
-    require.extensions[extension] = function (module, filename) {
+    require.extensions[extension] = function(module, filename) {
       // Override the require method for this module
       module.require = self._require.bind(self, module, stubs);
 
@@ -291,8 +290,8 @@ Proxyquire.prototype._overrideExtensionHandlers = function (module, stubs) {
   });
 
   // Return a function that will undo what we just did
-  return function () {
-    Object.keys(originalExtensions).forEach(function (extension) {
+  return function() {
+    Object.keys(originalExtensions).forEach(function(extension) {
       require.extensions[extension] = originalExtensions[extension];
     });
   };

--- a/lib/proxyquire.js
+++ b/lib/proxyquire.js
@@ -31,6 +31,16 @@ function validateArguments(request, stubs) {
   if (msg) throw new ProxyquireError(msg);
 }
 
+function defaultNameResolver(stubs, fileName) {
+  if (stubs.hasOwnProperty(fileName)) {
+    return stubs[fileName];
+  }
+}
+
+function resolveStub(stubs, fileName, module) {
+  return (this._nameResolver ? this._nameResolver : defaultNameResolver)(stubs, fileName, module.filename);
+}
+
 function Proxyquire(parent) {
   var self = this
     , fn = self.load.bind(self)
@@ -39,6 +49,9 @@ function Proxyquire(parent) {
 
   this._parent = parent;
   this._preserveCache = true;
+  this._nameResolver = undefined;
+  this._noCallThru = undefined;
+
 
   Object.keys(proto)
     .forEach(function (key) {
@@ -48,6 +61,20 @@ function Proxyquire(parent) {
   self.fn = fn;
   return fn;
 }
+
+/**
+ * Sets new module name resolver and comparator
+ * @name resolveNames
+ * @function
+ * @param {Function} [resolver](subs, fileName, currentDir).
+ * @return {object} The proxyquire function to allow chaining
+ *
+ * @example proxyquire.resolveNames((stubs, fileName) => stubs.hasOwnProperty(fileName) ? stubs[fileName] : null)
+ */
+Proxyquire.prototype.resolveNames = function (fn) {
+  this._nameResolver = fn;
+  return this.fn;
+};
 
 /**
  * Disables call thru, which determines if keys of original modules will be used
@@ -76,7 +103,7 @@ Proxyquire.prototype.callThru = function () {
 };
 
 /**
- * Will make proxyquire remove the requested modules from the `require.cache` in order to force 
+ * Will make proxyquire remove the requested modules from the `require.cache` in order to force
  * them to be reloaded the next time they are proxyquired.
  * This behavior differs from the way nodejs `require` works, but for some tests this maybe useful.
  *
@@ -85,20 +112,20 @@ Proxyquire.prototype.callThru = function () {
  * @private
  * @return {object} The proxyquire function to allow chaining
  */
-Proxyquire.prototype.noPreserveCache = function() {
+Proxyquire.prototype.noPreserveCache = function () {
   this._preserveCache = false;
   return this.fn;
 };
 
 /**
- * Restores proxyquire caching behavior to match the one of nodejs `require` 
+ * Restores proxyquire caching behavior to match the one of nodejs `require`
  *
  * @name preserveCache
  * @function
  * @private
  * @return {object} The proxyquire function to allow chaining
  */
-Proxyquire.prototype.preserveCache = function() {
+Proxyquire.prototype.preserveCache = function () {
   this._preserveCache = true;
   return this.fn;
 };
@@ -137,13 +164,12 @@ Proxyquire.prototype.load = function (request, stubs) {
 };
 
 // This replaces a module's require function
-Proxyquire.prototype._require = function(module, stubs, path) {
+Proxyquire.prototype._require = function (module, stubs, path) {
   assert(typeof path === 'string', 'path must be a string');
   assert(path, 'missing path');
 
-  if (hasOwnProperty.call(stubs, path)) {
-    var stub = stubs[path];
-
+  var stub = resolveStub.call(this, stubs, path, module);
+  if (typeof stub != 'undefined') {
     if (stub === null) {
       // Mimic the module-not-found exception thrown by node.js.
       throw moduleNotFoundError(path);
@@ -167,7 +193,7 @@ Proxyquire.prototype._require = function(module, stubs, path) {
   }
 };
 
-Proxyquire.prototype._withoutCache = function(module, stubs, path, func) {
+Proxyquire.prototype._withoutCache = function (module, stubs, path, func) {
   // Temporarily disable the cache - either per-module or globally if we have global stubs
   var restoreCache = this._disableCache(module, path);
 
@@ -190,12 +216,13 @@ Proxyquire.prototype._withoutCache = function(module, stubs, path, func) {
             extensions: Object.keys(require.extensions),
             paths: Module.globalPaths
           })
-        } catch (_) {}
+        } catch (_) {
+        }
       });
       var ids = [id].concat(stubIds.filter(Boolean));
 
       ids.forEach(function (id) {
-        delete require.cache[id];        
+        delete require.cache[id];
       });
     }
 
@@ -204,7 +231,7 @@ Proxyquire.prototype._withoutCache = function(module, stubs, path, func) {
   }
 };
 
-Proxyquire.prototype._disableCache = function(module, path) {
+Proxyquire.prototype._disableCache = function (module, path) {
   if (this._containsGlobal) {
     // empty the require cache because if we are stubbing C but requiring A,
     // and if A requires B and B requires C, then B and C might be cached already
@@ -216,17 +243,17 @@ Proxyquire.prototype._disableCache = function(module, path) {
   return this._disableModuleCache(path, module);
 };
 
-Proxyquire.prototype._disableGlobalCache = function() {
+Proxyquire.prototype._disableGlobalCache = function () {
   var cache = require.cache;
   require.cache = Module._cache = {};
 
   // Return a function that will undo what we just did
-  return function() {
+  return function () {
     require.cache = Module._cache = cache;
   };
 };
 
-Proxyquire.prototype._disableModuleCache = function(path, module) {
+Proxyquire.prototype._disableModuleCache = function (path, module) {
   // Find the ID (location) of the SUT, relative to the parent
   var id = Module._resolveFilename(path, module);
 
@@ -234,25 +261,25 @@ Proxyquire.prototype._disableModuleCache = function(path, module) {
   delete Module._cache[id];
 
   // Return a function that will undo what we just did
-  return function() {
+  return function () {
     if (cached) {
       Module._cache[id] = cached;
     }
   };
 };
 
-Proxyquire.prototype._overrideExtensionHandlers = function(module, stubs) {
+Proxyquire.prototype._overrideExtensionHandlers = function (module, stubs) {
   var originalExtensions = {};
   var self = this;
 
-  Object.keys(require.extensions).forEach(function(extension) {
+  Object.keys(require.extensions).forEach(function (extension) {
     // Store the original so we can restore it later
     if (!originalExtensions[extension]) {
       originalExtensions[extension] = require.extensions[extension];
     }
 
     // Override the default handler for the requested file extension
-    require.extensions[extension] = function(module, filename) {
+    require.extensions[extension] = function (module, filename) {
       // Override the require method for this module
       module.require = self._require.bind(self, module, stubs);
 
@@ -261,8 +288,8 @@ Proxyquire.prototype._overrideExtensionHandlers = function(module, stubs) {
   });
 
   // Return a function that will undo what we just did
-  return function() {
-    Object.keys(originalExtensions).forEach(function(extension) {
+  return function () {
+    Object.keys(originalExtensions).forEach(function (extension) {
       require.extensions[extension] = originalExtensions[extension];
     });
   };

--- a/lib/proxyquire.js
+++ b/lib/proxyquire.js
@@ -54,7 +54,7 @@ function Proxyquire(parent) {
 
 
   Object.keys(proto)
-    .forEach(function(key) {
+    .forEach(function (key) {
       if (is.Function(proto[key])) fn[key] = proto[key].bind(self);
     });
 
@@ -71,7 +71,7 @@ function Proxyquire(parent) {
  *
  * @example proxyquire.resolveNames((stubs, fileName) => stubs.hasOwnProperty(fileName) ? stubs[fileName] : null)
  */
-Proxyquire.prototype.resolveNames = function(fn) {
+Proxyquire.prototype.resolveNames = function (fn) {
   this._nameResolver = fn;
   return this.fn;
 };
@@ -84,7 +84,7 @@ Proxyquire.prototype.resolveNames = function(fn) {
  * @private
  * @return {object} The proxyquire function to allow chaining
  */
-Proxyquire.prototype.noCallThru = function() {
+Proxyquire.prototype.noCallThru = function () {
   this._noCallThru = true;
   return this.fn;
 };
@@ -97,7 +97,7 @@ Proxyquire.prototype.noCallThru = function() {
  * @private
  * @return {object} The proxyquire function to allow chaining
  */
-Proxyquire.prototype.callThru = function() {
+Proxyquire.prototype.callThru = function () {
   this._noCallThru = false;
   return this.fn;
 };
@@ -112,7 +112,7 @@ Proxyquire.prototype.callThru = function() {
  * @private
  * @return {object} The proxyquire function to allow chaining
  */
-Proxyquire.prototype.noPreserveCache = function() {
+Proxyquire.prototype.noPreserveCache = function () {
   this._preserveCache = false;
   return this.fn;
 };
@@ -125,7 +125,7 @@ Proxyquire.prototype.noPreserveCache = function() {
  * @private
  * @return {object} The proxyquire function to allow chaining
  */
-Proxyquire.prototype.preserveCache = function() {
+Proxyquire.prototype.preserveCache = function () {
   this._preserveCache = true;
   return this.fn;
 };
@@ -136,7 +136,7 @@ Proxyquire.prototype.preserveCache = function() {
  * @param stubs The stubs to use. e.g., { "path": { extname: function() { ... } } }
  * @return {*} A newly resolved module with the given stubs.
  */
-Proxyquire.prototype.load = function(request, stubs) {
+Proxyquire.prototype.load = function (request, stubs) {
   validateArguments(request, stubs);
 
   // Find out if any of the passed stubs are global overrides
@@ -164,7 +164,7 @@ Proxyquire.prototype.load = function(request, stubs) {
 };
 
 // This replaces a module's require function
-Proxyquire.prototype._require = function(module, stubs, path) {
+Proxyquire.prototype._require = function (module, stubs, path) {
   assert(typeof path === 'string', 'path must be a string');
   assert(path, 'missing path');
 
@@ -196,7 +196,7 @@ Proxyquire.prototype._require = function(module, stubs, path) {
   }
 };
 
-Proxyquire.prototype._withoutCache = function(module, stubs, path, func) {
+Proxyquire.prototype._withoutCache = function (module, stubs, path, func) {
   // Temporarily disable the cache - either per-module or globally if we have global stubs
   var restoreCache = this._disableCache(module, path);
 
@@ -212,7 +212,7 @@ Proxyquire.prototype._withoutCache = function(module, stubs, path, func) {
       restoreCache();
     } else {
       var id = Module._resolveFilename(path, module);
-      var stubIds = Object.keys(stubs).map(function(stubPath) {
+      var stubIds = Object.keys(stubs).map(function (stubPath) {
         try {
           return resolve.sync(stubPath, {
             basedir: dirname(id),
@@ -224,7 +224,7 @@ Proxyquire.prototype._withoutCache = function(module, stubs, path, func) {
       });
       var ids = [id].concat(stubIds.filter(Boolean));
 
-      ids.forEach(function(id) {
+      ids.forEach(function (id) {
         delete require.cache[id];
       });
     }
@@ -234,7 +234,7 @@ Proxyquire.prototype._withoutCache = function(module, stubs, path, func) {
   }
 };
 
-Proxyquire.prototype._disableCache = function(module, path) {
+Proxyquire.prototype._disableCache = function (module, path) {
   if (this._containsGlobal) {
     // empty the require cache because if we are stubbing C but requiring A,
     // and if A requires B and B requires C, then B and C might be cached already
@@ -246,17 +246,17 @@ Proxyquire.prototype._disableCache = function(module, path) {
   return this._disableModuleCache(path, module);
 };
 
-Proxyquire.prototype._disableGlobalCache = function() {
+Proxyquire.prototype._disableGlobalCache = function () {
   var cache = require.cache;
   require.cache = Module._cache = {};
 
   // Return a function that will undo what we just did
-  return function() {
+  return function () {
     require.cache = Module._cache = cache;
   };
 };
 
-Proxyquire.prototype._disableModuleCache = function(path, module) {
+Proxyquire.prototype._disableModuleCache = function (path, module) {
   // Find the ID (location) of the SUT, relative to the parent
   var id = Module._resolveFilename(path, module);
 
@@ -264,25 +264,25 @@ Proxyquire.prototype._disableModuleCache = function(path, module) {
   delete Module._cache[id];
 
   // Return a function that will undo what we just did
-  return function() {
+  return function () {
     if (cached) {
       Module._cache[id] = cached;
     }
   };
 };
 
-Proxyquire.prototype._overrideExtensionHandlers = function(module, stubs) {
+Proxyquire.prototype._overrideExtensionHandlers = function (module, stubs) {
   var originalExtensions = {};
   var self = this;
 
-  Object.keys(require.extensions).forEach(function(extension) {
+  Object.keys(require.extensions).forEach(function (extension) {
     // Store the original so we can restore it later
     if (!originalExtensions[extension]) {
       originalExtensions[extension] = require.extensions[extension];
     }
 
     // Override the default handler for the requested file extension
-    require.extensions[extension] = function(module, filename) {
+    require.extensions[extension] = function (module, filename) {
       // Override the require method for this module
       module.require = self._require.bind(self, module, stubs);
 
@@ -291,8 +291,8 @@ Proxyquire.prototype._overrideExtensionHandlers = function(module, stubs) {
   });
 
   // Return a function that will undo what we just did
-  return function() {
-    Object.keys(originalExtensions).forEach(function(extension) {
+  return function () {
+    Object.keys(originalExtensions).forEach(function (extension) {
       require.extensions[extension] = originalExtensions[extension];
     });
   };

--- a/lib/proxyquire.js
+++ b/lib/proxyquire.js
@@ -25,7 +25,7 @@ function validateArguments(request, stubs) {
       return 'Invalid argument: "request". Needs to be a requirable string that is the module to load.';
 
     if (!is.Object(stubs))
-      return 'Invalid argument: "stubs". Needs to be an object containing overrides e.g., {"path": { extname: function () { ... } } }.';
+      return 'Invalid argument: "stubs". Needs to be an object containing overrides e.g., {"path": { extname: function() { ... } } }.';
   })();
 
   if (msg) throw new ProxyquireError(msg);
@@ -54,7 +54,7 @@ function Proxyquire(parent) {
 
 
   Object.keys(proto)
-    .forEach(function (key) {
+    .forEach(function(key) {
       if (is.Function(proto[key])) fn[key] = proto[key].bind(self);
     });
 
@@ -71,7 +71,7 @@ function Proxyquire(parent) {
  *
  * @example proxyquire.resolveNames((stubs, fileName) => stubs.hasOwnProperty(fileName) ? stubs[fileName] : null)
  */
-Proxyquire.prototype.resolveNames = function (fn) {
+Proxyquire.prototype.resolveNames = function(fn) {
   this._nameResolver = fn;
   return this.fn;
 };
@@ -84,7 +84,7 @@ Proxyquire.prototype.resolveNames = function (fn) {
  * @private
  * @return {object} The proxyquire function to allow chaining
  */
-Proxyquire.prototype.noCallThru = function () {
+Proxyquire.prototype.noCallThru = function() {
   this._noCallThru = true;
   return this.fn;
 };
@@ -97,7 +97,7 @@ Proxyquire.prototype.noCallThru = function () {
  * @private
  * @return {object} The proxyquire function to allow chaining
  */
-Proxyquire.prototype.callThru = function () {
+Proxyquire.prototype.callThru = function() {
   this._noCallThru = false;
   return this.fn;
 };
@@ -112,7 +112,7 @@ Proxyquire.prototype.callThru = function () {
  * @private
  * @return {object} The proxyquire function to allow chaining
  */
-Proxyquire.prototype.noPreserveCache = function () {
+Proxyquire.prototype.noPreserveCache = function() {
   this._preserveCache = false;
   return this.fn;
 };
@@ -125,7 +125,7 @@ Proxyquire.prototype.noPreserveCache = function () {
  * @private
  * @return {object} The proxyquire function to allow chaining
  */
-Proxyquire.prototype.preserveCache = function () {
+Proxyquire.prototype.preserveCache = function() {
   this._preserveCache = true;
   return this.fn;
 };
@@ -133,10 +133,10 @@ Proxyquire.prototype.preserveCache = function () {
 /**
  * Loads a module using the given stubs instead of their normally resolved required modules.
  * @param request The requirable module path to load.
- * @param stubs The stubs to use. e.g., { "path": { extname: function () { ... } } }
+ * @param stubs The stubs to use. e.g., { "path": { extname: function() { ... } } }
  * @return {*} A newly resolved module with the given stubs.
  */
-Proxyquire.prototype.load = function (request, stubs) {
+Proxyquire.prototype.load = function(request, stubs) {
   validateArguments(request, stubs);
 
   // Find out if any of the passed stubs are global overrides
@@ -164,7 +164,7 @@ Proxyquire.prototype.load = function (request, stubs) {
 };
 
 // This replaces a module's require function
-Proxyquire.prototype._require = function (module, stubs, path) {
+Proxyquire.prototype._require = function(module, stubs, path) {
   assert(typeof path === 'string', 'path must be a string');
   assert(path, 'missing path');
 
@@ -196,7 +196,7 @@ Proxyquire.prototype._require = function (module, stubs, path) {
   }
 };
 
-Proxyquire.prototype._withoutCache = function (module, stubs, path, func) {
+Proxyquire.prototype._withoutCache = function(module, stubs, path, func) {
   // Temporarily disable the cache - either per-module or globally if we have global stubs
   var restoreCache = this._disableCache(module, path);
 
@@ -212,7 +212,7 @@ Proxyquire.prototype._withoutCache = function (module, stubs, path, func) {
       restoreCache();
     } else {
       var id = Module._resolveFilename(path, module);
-      var stubIds = Object.keys(stubs).map(function (stubPath) {
+      var stubIds = Object.keys(stubs).map(function(stubPath) {
         try {
           return resolve.sync(stubPath, {
             basedir: dirname(id),
@@ -224,7 +224,7 @@ Proxyquire.prototype._withoutCache = function (module, stubs, path, func) {
       });
       var ids = [id].concat(stubIds.filter(Boolean));
 
-      ids.forEach(function (id) {
+      ids.forEach(function(id) {
         delete require.cache[id];
       });
     }
@@ -234,7 +234,7 @@ Proxyquire.prototype._withoutCache = function (module, stubs, path, func) {
   }
 };
 
-Proxyquire.prototype._disableCache = function (module, path) {
+Proxyquire.prototype._disableCache = function(module, path) {
   if (this._containsGlobal) {
     // empty the require cache because if we are stubbing C but requiring A,
     // and if A requires B and B requires C, then B and C might be cached already
@@ -246,17 +246,17 @@ Proxyquire.prototype._disableCache = function (module, path) {
   return this._disableModuleCache(path, module);
 };
 
-Proxyquire.prototype._disableGlobalCache = function () {
+Proxyquire.prototype._disableGlobalCache = function() {
   var cache = require.cache;
   require.cache = Module._cache = {};
 
   // Return a function that will undo what we just did
-  return function () {
+  return function() {
     require.cache = Module._cache = cache;
   };
 };
 
-Proxyquire.prototype._disableModuleCache = function (path, module) {
+Proxyquire.prototype._disableModuleCache = function(path, module) {
   // Find the ID (location) of the SUT, relative to the parent
   var id = Module._resolveFilename(path, module);
 
@@ -264,25 +264,25 @@ Proxyquire.prototype._disableModuleCache = function (path, module) {
   delete Module._cache[id];
 
   // Return a function that will undo what we just did
-  return function () {
+  return function() {
     if (cached) {
       Module._cache[id] = cached;
     }
   };
 };
 
-Proxyquire.prototype._overrideExtensionHandlers = function (module, stubs) {
+Proxyquire.prototype._overrideExtensionHandlers = function(module, stubs) {
   var originalExtensions = {};
   var self = this;
 
-  Object.keys(require.extensions).forEach(function (extension) {
+  Object.keys(require.extensions).forEach(function(extension) {
     // Store the original so we can restore it later
     if (!originalExtensions[extension]) {
       originalExtensions[extension] = require.extensions[extension];
     }
 
     // Override the default handler for the requested file extension
-    require.extensions[extension] = function (module, filename) {
+    require.extensions[extension] = function(module, filename) {
       // Override the require method for this module
       module.require = self._require.bind(self, module, stubs);
 
@@ -291,8 +291,8 @@ Proxyquire.prototype._overrideExtensionHandlers = function (module, stubs) {
   });
 
   // Return a function that will undo what we just did
-  return function () {
-    Object.keys(originalExtensions).forEach(function (extension) {
+  return function() {
+    Object.keys(originalExtensions).forEach(function(extension) {
       require.extensions[extension] = originalExtensions[extension];
     });
   };

--- a/lib/proxyquire.js
+++ b/lib/proxyquire.js
@@ -180,7 +180,10 @@ Proxyquire.prototype._require = function (module, stubs, path) {
     }
 
     // We are top level or this stub is marked as global
-    if (module.parent == this._parent || hasOwnProperty.call(stub, '@global') || hasOwnProperty.call(stub, '@runtimeGlobal')) {
+    if (module.parent == this._parent
+      || hasOwnProperty.call(stub, '@global')
+      || hasOwnProperty.call(stub, '@runtimeGlobal')
+      || hasOwnProperty.call(stub, '@override')) {
       return stub;
     }
   }

--- a/test/proxyquire-nameresolver.js
+++ b/test/proxyquire-nameresolver.js
@@ -1,0 +1,37 @@
+/*jshint asi:true*/
+/*global describe, before, beforeEach, it */
+'use strict';
+
+var assert = require('assert')
+  , realFoo = require('./samples/foo')
+  , path = require('path');
+
+var stubs = {
+  'samples/bar': {
+    rab: function () {
+      return 'resolved'
+    }
+  }
+};
+
+function resolver(stubs, fileName, module) {
+  var dirname = path.dirname(module);
+  var requireName = fileName.charAt(0) == '.' ? path.normalize(dirname + '/' + fileName) : fileName;
+  for (var i in stubs) {
+    if (requireName.indexOf(i) > 0) {
+      return stubs[i]
+    }
+  }
+}
+
+describe('nameresolver', function () {
+  describe('override', function () {
+    var proxyquire = require('..')
+
+    it('proxyquire can load module buy half name', function () {
+      var proxiedFoo = proxyquire.resolveNames(resolver).load('./samples/foo', stubs);
+
+      assert.equal(proxiedFoo.bigRab(), 'RESOLVED');
+    });
+  });
+});

--- a/test/proxyquire-nameresolver.js
+++ b/test/proxyquire-nameresolver.js
@@ -2,36 +2,101 @@
 /*global describe, before, beforeEach, it */
 'use strict';
 
+var realFoo = require('./samples/foo')
+  , Module = require('module');
+
 var assert = require('assert')
-  , realFoo = require('./samples/foo')
   , path = require('path');
+
 
 var stubs = {
   'samples/bar': {
     rab: function () {
       return 'resolved'
     }
+  },
+  '/sub.js': {
+    subFn: function () {
+      return 'override';
+    },
+    '@override':true
   }
 };
 
 function resolver(stubs, fileName, module) {
-  var dirname = path.dirname(module);
-  var requireName = fileName.charAt(0) == '.' ? path.normalize(dirname + '/' + fileName) : fileName;
+  var dirname = module ? path.dirname(module) : '';
+  var requireName = fileName;
+  if (dirname) {
+    requireName = fileName.charAt(0) == '.' ? path.normalize(dirname + '/' + fileName) : fileName;
+  }
+
   for (var i in stubs) {
     if (requireName.indexOf(i) > 0) {
-      return stubs[i]
+      return stubs[i];
     }
   }
 }
 
-describe('nameresolver', function () {
-  describe('override', function () {
-    var proxyquire = require('..')
+function wipeCache(stubs, resolver, testCallback) {
+  if (!testCallback) {
+    testCallback = function () {
+      return true;
+    }
+  }
+  var cache = require.cache;
+  var wipeList = [];
+  var removedList = [];
+  var newCache = Object.assign({}, cache);
+  var objects = Object.keys(newCache);
+  objects.forEach(function (moduleName) {
+    var test = resolver(stubs, moduleName);
+    if (test) {
+      wipeList.push(moduleName);
+      removedList.push(moduleName);
+      delete newCache[moduleName];
+    }
+  });
 
-    it('proxyquire can load module buy half name', function () {
-      var proxiedFoo = proxyquire.resolveNames(resolver).load('./samples/foo', stubs);
+  while (wipeList.length) {
+    var objects = Object.keys(newCache);
+    var removeList = wipeList;
+    wipeList = [];
 
-      assert.equal(proxiedFoo.bigRab(), 'RESOLVED');
+    objects.forEach(function (moduleName) {
+      if (testCallback(moduleName)) {
+        var subCache = newCache[moduleName].children;
+        subCache.forEach(function (subModule) {
+          if (removeList.indexOf(subModule.filename) >= 0) {
+            wipeList.push(moduleName);
+            removedList.push(moduleName);
+            delete newCache[moduleName];
+          }
+        });
+      }
+    });
+  }
+  require.cache = Module._cache = newCache;
+}
+
+wipeCache(stubs, resolver, function (moduleName) {
+  return moduleName.indexOf('/samples/') > 0;
+});
+
+var proxyquire = require('..')
+var proxiedFoo = proxyquire.resolveNames(resolver).load('./samples/foo', stubs);
+console.log(proxiedFoo.testSub());
+
+if (0) {
+
+  describe('nameresolver', function () {
+    describe('override', function () {
+      var proxyquire = require('..')
+
+      it('proxyquire can load module buy half name', function () {
+        var proxiedFoo = proxyquire.resolveNames(resolver).load('./samples/foo', stubs);
+
+        assert.equal(proxiedFoo.bigRab(), 'RESOLVED');
+      });
     });
   });
-});
+}

--- a/test/samples/bar.js
+++ b/test/samples/bar.js
@@ -1,3 +1,5 @@
+var Sub=require('./sub.js');
+
 function bar () {
   return 'bar';
 }
@@ -6,5 +8,10 @@ function rab () {
   return 'rab';
 }
 
-module.exports = { bar : bar, rab: rab };
+function sub () {
+  return Sub.subFn();
+}
+
+
+module.exports = { bar : bar, rab: rab, sub: sub };
 

--- a/test/samples/bar.js
+++ b/test/samples/bar.js
@@ -1,4 +1,4 @@
-var Sub=require('./sub.js');
+var subModule=require('./sub.js');
 
 function bar () {
   return 'bar';
@@ -9,7 +9,7 @@ function rab () {
 }
 
 function sub () {
-  return Sub.subFn();
+  return subModule.subFn();
 }
 
 

--- a/test/samples/boof.js
+++ b/test/samples/boof.js
@@ -1,1 +1,2 @@
+require('./sub.js');
 module.exports = 'boof'

--- a/test/samples/foo.js
+++ b/test/samples/foo.js
@@ -1,5 +1,3 @@
-console.log('<<foo.js');
-
 var stats = require('./stats')
   , bar = require('./bar')
   , boof = require('./boof')

--- a/test/samples/foo.js
+++ b/test/samples/foo.js
@@ -1,3 +1,5 @@
+console.log('<<foo.js');
+
 var stats = require('./stats')
   , bar = require('./bar')
   , boof = require('./boof')
@@ -34,6 +36,10 @@ function bigCrypto () {
   return crypto;
 }
 
+function testSub(){
+  return bar.sub();
+}
+
 module.exports = {
     bigBar: bigBar
   , bigRab: bigRab
@@ -44,4 +50,5 @@ module.exports = {
   , foobool: foobool
   , bigCrypto: bigCrypto
   , state: ''
+  , testSub: testSub
 };

--- a/test/samples/sub.js
+++ b/test/samples/sub.js
@@ -1,4 +1,3 @@
-console.log('<<sub!');
 module.exports = {
   subFn: function () {
     return 'sub';

--- a/test/samples/sub.js
+++ b/test/samples/sub.js
@@ -1,7 +1,6 @@
-console.log('<<sub.js');
-
+console.log('<<sub!');
 module.exports = {
   subFn: function () {
     return 'sub';
   }
-}
+};

--- a/test/samples/sub.js
+++ b/test/samples/sub.js
@@ -1,0 +1,7 @@
+console.log('<<sub.js');
+
+module.exports = {
+  subFn: function () {
+    return 'sub';
+  }
+}


### PR DESCRIPTION
Every time you use proxyquire – you should provide stubs names exactly as they appears in require.
It is not very useful, cos require perform some kind of name resolving.
Some time It is not even possible. For example if you have ES6 code and webpack around it – all yours `imports` will be transformed into `require` with relative file path. 
And you will dont know that __always different__ path.

Solution is simple - add nameResolver, and find stub to override not buy extract match, but by any logic you provide.
Also I have to introduce '@override' flag, to do able to override stubs deeply inside, with out using globals.

PS: By default proxyquire keeps old behavior.
PPS: Test case for nameResolver also contain function for 'smart' wiping node cache ([wipenodecache](https://github.com/theKashey/wipeNodeCache)). One can not use @global - one cannot wipe everything. 
I am sure - you shall not use global overrides
I am sure - it is useful to override something on the deeps. Some sort of tests(integration for example) requires it.