### PR TITLE
Only remove non-native modules from cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,11 @@ node_js:
   - '0.10'
   - '4'
   - '6'
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8

--- a/lib/proxyquire.js
+++ b/lib/proxyquire.js
@@ -220,8 +220,25 @@ Proxyquire.prototype._disableGlobalCache = function() {
   var cache = require.cache;
   require.cache = Module._cache = {};
 
+  for (var id in cache) {
+    // Keep native modules (i.e. `.node` files).
+    // Otherwise, Node.js would throw a “Module did not self-register”
+    // error upon requiring it a second time.
+    // See https://github.com/nodejs/node/issues/5016.
+    if (/\.node$/.test(id)) {
+      require.cache[id] = cache[id];
+    }
+  }
+
   // Return a function that will undo what we just did
   return function() {
+    // Keep native modules which were added to the cache in the meantime.
+    for (var id in require.cache) {
+      if (/\.node$/.test(id)) {
+        cache[id] = require.cache[id]
+      }
+    }
+
     require.cache = Module._cache = cache;
   };
 };

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "license": "MIT",
   "devDependencies": {
     "mocha": "~3.1",
+    "native-hello-world": "^1.0.0",
     "should": "~3.3",
     "sinon": "~1.9"
   },

--- a/test/proxyquire-global.js
+++ b/test/proxyquire-global.js
@@ -39,6 +39,17 @@ describe('global flags set', function () {
     assert.equal(realFoo(), false);
     assert.equal(proxiedFoo(), true);
   });
+
+  it('should not throw when a native module is required a second time', function () {
+    var stubs = {
+      'foo': {
+        '@global': true
+      }
+    };
+
+    proxyquire('native-hello-world', stubs)
+    proxyquire('native-hello-world', stubs)
+  })
 });
 
 describe('global flags not set', function () {


### PR DESCRIPTION
As discussed in #109 and #108, we should only remove non-native modules from the cache because, upon requiring a native module a second time, it causes a “Module did not self-register” error (see https://github.com/nodejs/node/issues/5016).

I thought about adding a similar check to [`_withoutCache` when `noPreserveCache()` is used](https://github.com/thlorenz/proxyquire/blob/v1.7.10/lib/proxyquire.js#L198) but I’m not sure if that’s desirable because it conveys the idea that native modules can be cleared from cache. Maybe we should add a note explaining that `noPreserveCache()` shouldn’t be used when stubbing native modules?