### PR TITLE
Allow inheritance from proxyquire

### DIFF
--- a/lib/proxyquire.js
+++ b/lib/proxyquire.js
@@ -42,7 +42,7 @@ function Proxyquire(parent) {
 
   Object.keys(proto)
     .forEach(function (key) {
-      if (is.Function(proto[key])) fn[key] = proto[key].bind(self);
+      if (is.Function(proto[key])) fn[key] = self[key].bind(self);
     });
 
   self.fn = fn;


### PR DESCRIPTION
My [last pull request](https://github.com/thlorenz/proxyquire/pull/148), about extending functionality is closed, and let it be so. 
I am happy with my fork. But I am the only one. And sometimes I still have to use real proxyquire, and sometimes it is not easy.

This little pull request just enables inheritance. So one can not fork proxyquire, but inherit from it and apply changes he (no matter why) wants.

so just use refs from top level prototype.

example ([real code](https://github.com/theKashey/proxyquire-webpack-alias/blob/master/src/index.js) ): 
```javascript
 class ProxyquireForWebpackAlias extends Proxyquire {
   load(fileName, stubs){
     // as discussed in PR-148 - modify list of stubs, not proxyquire.
     return super.load(fileName, convertAliasesIntoRelative(stubs)); 
   }
 }
```

One line. Very simple. Nothing to be broken. Something to be enabled.