### PR TITLE
Make unit test more unit.

### DIFF
--- a/lib/proxyquire.js
+++ b/lib/proxyquire.js
@@ -63,6 +63,54 @@ Proxyquire.prototype.noCallThru = function () {
 };
 
 /**
+ * Throws an error is some stubs are unused
+ * @name noUnusedStubs
+ * @function
+ * @private
+ * @return {object} The proxyquire function to allow chaining
+ */
+Proxyquire.prototype.noUnusedStubs = function () {
+  this._noUnusedStubs = true;
+  return this.fn;
+};
+
+/**
+ * Restores default behavior - allows any stubs
+ * @name anyStub
+ * @function
+ * @private
+ * @return {object} The proxyquire function to allow chaining
+ */
+Proxyquire.prototype.anyStub = function () {
+  this._noUnusedStubs = false;
+  return this.fn;
+};
+
+/**
+ * Throws an error is some deps are not mocked
+ * @name noUnmockedStubs
+ * @function
+ * @private
+ * @return {object} The proxyquire function to allow chaining
+ */
+Proxyquire.prototype.noUnmockedStubs = function () {
+  this._noUnmockedStubs = true;
+  return this.fn;
+};
+
+/**
+ * Restores default behavior - allows unmocked deps
+ * @name withUnmockedStubs
+ * @function
+ * @private
+ * @return {object} The proxyquire function to allow chaining
+ */
+Proxyquire.prototype.withUnmockedStubs = function () {
+  this._noUnmockedStubs = false;
+  return this.fn;
+};
+
+/**
  * Enables call thru, which determines if keys of original modules will be used
  * when they weren't stubbed out.
  * @name callThru
@@ -132,8 +180,18 @@ Proxyquire.prototype.load = function (request, stubs) {
     }
   }
 
+  this._stubsUsed = {};
   // Ignore the module cache when return the requested module
-  return this._withoutCache(this._parent, stubs, request, this._parent.require.bind(this._parent, request));
+  var result = this._withoutCache(this._parent, stubs, request, this._parent.require.bind(this._parent, request));
+
+  if (this._noUnusedStubs) {
+    for (var key in stubs) {
+      if (!this._stubsUsed[key]) {
+        throw new Error('proxyquire: stub `' + key + '` dont match any require');
+      }
+    }
+  }
+  return result;
 };
 
 // This replaces a module's require function
@@ -149,6 +207,8 @@ Proxyquire.prototype._require = function(module, stubs, path) {
       throw moduleNotFoundError(path);
     }
 
+    this._stubsUsed[path] = true;
+
     if (hasOwnProperty.call(stub, '@noCallThru') ? !stub['@noCallThru'] : !this._noCallThru) {
       fillMissingKeys(stub, Module._load(path, module));
     }
@@ -156,6 +216,12 @@ Proxyquire.prototype._require = function(module, stubs, path) {
     // We are top level or this stub is marked as global
     if (module.parent == this._parent || hasOwnProperty.call(stub, '@global') || hasOwnProperty.call(stub, '@runtimeGlobal')) {
       return stub;
+    }
+  } else {
+    if (this._noUnmockedStubs) {
+      if (module.parent == this._parent) {
+        throw new Error('proxyquire: dependency `' + path + ' of `'+this._parent+'` is is not mocked');
+      }
     }
   }
 

--- a/lib/proxyquire.js
+++ b/lib/proxyquire.js
@@ -218,10 +218,8 @@ Proxyquire.prototype._require = function(module, stubs, path) {
       return stub;
     }
   } else {
-    if (this._noUnmockedStubs) {
-      if (module.parent == this._parent) {
-        throw new Error('proxyquire: dependency `' + path + ' of `'+this._parent+'` is is not mocked');
-      }
+    if (this._noUnmockedStubs && module.parent == this._parent) {
+      throw new Error('proxyquire: dependency `' + path + ' of `' + this._parent + '` is is not mocked');
     }
   }
 

--- a/test/proxyquire-nounused.js
+++ b/test/proxyquire-nounused.js
@@ -1,0 +1,35 @@
+'use strict';
+/*jshint asi:true*/
+/*global describe, before, beforeEach, it */
+
+var assert = require('assert')
+  , proxyquire = require('..')
+  , path = require('path')
+  , fooPath = path.join(__dirname, './samples/foo-singleton.js');
+
+describe('When resolving something unused', function () {
+
+  it('should work in default behavior', function () {
+    proxyquire.load(fooPath, {
+      '/not/used.js': { a: 'b' },
+      'path': { a: 'b' }
+    })
+  });
+
+  it('throws error if stubs is not used', function () {
+    assert.throws(function () {
+      proxyquire.noUnusedStubs().load(fooPath, {
+        '/not/used.js': { a: 'b' },
+        'path': { a: 'b' }
+      })
+    });
+  });
+
+  it('throws error if stubs is not used', function () {
+    assert.throws(function () {
+      proxyquire.noUnmockedStubs().load(fooPath, {
+        //'path': { a: 'b' }
+      })
+    });
+  })
+})


### PR DESCRIPTION
By definition unit test should test a unit within isolation. With zero external dependancies.
To achieve this goal I am introducing new command - `noUnmockedStubs`. If you did not mock everything - it will fail.
(not mock, just dont list it in stubs)

In other ways - sometimes you may refactor code, remove dep, and keep it in test file.
In result test behavior may not match real behavior.

To achieve this goal I am introducing new command - `noUnusedStubs`. If you mocking something you are really not using - it will fail.

Both of these commands helps keep tests solid and provide more information about your`s mistakes.