### PR TITLE
Save node_modules!

### DIFF
--- a/lib/proxyquire.js
+++ b/lib/proxyquire.js
@@ -104,6 +104,33 @@ Proxyquire.prototype.preserveCache = function() {
 };
 
 /**
+ * Prevent modules from node_modules to be wiped from a cache
+ *
+ * @name onlyForProjectFiles
+ * @function
+ * @private
+ * @return {object} The proxyquire function to allow chaining
+ */
+Proxyquire.prototype.onlyForProjectFiles = function() {
+  this._onlyForProjectFiles = true;
+  return this.fn;
+};
+
+/**
+ * Restores default behavior - all modules can be wiped from a cache
+ *
+ * @name forAllFiles
+ * @function
+ * @private
+ * @return {object} The proxyquire function to allow chaining
+ */
+Proxyquire.prototype.forAllFiles = function() {
+  this._onlyForProjectFiles = false;
+  return this.fn;
+};
+
+
+/**
  * Loads a module using the given stubs instead of their normally resolved required modules.
  * @param request The requirable module path to load.
  * @param stubs The stubs to use. e.g., { "path": { extname: function () { ... } } }
@@ -218,28 +245,37 @@ Proxyquire.prototype._disableCache = function(module, path) {
 
 Proxyquire.prototype._disableGlobalCache = function() {
   var cache = require.cache;
+  var keepModules = this._onlyForProjectFiles;
   require.cache = Module._cache = {};
 
-  for (var id in cache) {
-    // Keep native modules (i.e. `.node` files).
-    // Otherwise, Node.js would throw a “Module did not self-register”
-    // error upon requiring it a second time.
-    // See https://github.com/nodejs/node/issues/5016.
-    if (/\.node$/.test(id)) {
-      require.cache[id] = cache[id];
+  function wipeCache(cache, restoredCache, target) {
+    for (var id in cache) {
+      if (
+      // Keep native modules (i.e. `.node` files).
+      // Otherwise, Node.js would throw a “Module did not self-register”
+      // error upon requiring it a second time.
+      // See https://github.com/nodejs/node/issues/5016.
+        (/\.node$/.test(id)) ||
+
+      // Keep third party modules, i.e. node_modules
+      // Otherwise, you will erase something you might not touch
+      // and few things, React, may just broke
+       (/\/node_modules\//.test(id) && keepModules) ||
+      //
+       0) {
+        target[id] = cache[id];
+      }
     }
+    return restoredCache;
   }
+
+  wipeCache(cache, {}, require.cache);
 
   // Return a function that will undo what we just did
   return function() {
     // Keep native modules which were added to the cache in the meantime.
-    for (var id in require.cache) {
-      if (/\.node$/.test(id)) {
-        cache[id] = require.cache[id]
-      }
-    }
 
-    require.cache = Module._cache = cache;
+    require.cache = Module._cache = wipeCache(require.cache, cache, cache);
   };
 };
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "mocha": "~3.1",
     "native-hello-world": "^1.0.0",
+    "simplest-counter": "^1.0.0",
     "should": "~3.3",
     "sinon": "~1.9"
   },

--- a/test/proxyquire-global.js
+++ b/test/proxyquire-global.js
@@ -83,3 +83,29 @@ describe('global flags not set', function () {
     assert.equal(proxiedFoo(), false);
   });
 });
+
+describe('global in node_modules', function () {
+  it('should not wipe node_modules', function () {
+
+    var test = require('./samples/using-node-modules');
+    assert.equal(test.fn(), "bar0");
+    assert.equal(test.fn(), "bar1");
+    // next call -> bar2 !
+
+    var stubs = {
+      'bar': {
+        '@runtimeGlobal': true
+      }
+    };
+
+    // should wipe
+    assert.equal(proxyquire('./samples/using-node-modules', stubs).fn(), "bar0");
+    assert.equal(proxyquire('./samples/using-node-modules', stubs).fn(), "bar0");
+
+    // next call -> bar2. Module restored from cache
+    assert.equal(proxyquire.onlyForProjectFiles().load('./samples/using-node-modules', stubs).fn(), "bar2");
+    assert.equal(proxyquire.onlyForProjectFiles().load('./samples/using-node-modules', stubs).fn(), "bar3");
+
+    proxyquire.forAllFiles();
+  });
+});

--- a/test/samples/using-node-modules.js
+++ b/test/samples/using-node-modules.js
@@ -1,0 +1,6 @@
+var module = require("simplest-counter");
+var bar = require("./bar.js");
+
+exports.fn = function () {
+  return bar.bar() + module.count();
+};


### PR DESCRIPTION
Very rare, but sometimes you have to override some global. 
And proxyquire will wipe require.cache to perform it.

Some time ago you `secure` native node.js modules from this, but, to say the truth, you should dont touch any non-project files.
As long you are not testing them, and not mocking - keep them alive.

And second important thing, from React world, you cannot mix together React components from different versions of React. Not versions - generations.

So, sometimes node_modules must be secured. And they can, cos they are third party libraries.

Solution - .onlyForProjectFiles and .forAllFiles.
PS: no changes in .ts file.