### PR TITLE
Add importable noCallThru version

### DIFF
--- a/nocallthru.js
+++ b/nocallthru.js
@@ -1,0 +1,8 @@
+'use strict'
+
+var Proxyquire = require('./lib/proxyquire')
+
+// delete this module from the cache to force re-require in order to allow resolving test module via parent.module
+delete require.cache[require.resolve(__filename)]
+
+module.exports = new Proxyquire(module.parent).noCallThru()


### PR DESCRIPTION
The noCallThru api is painful to use when `import`-ing rather than `require`-ing. I'm not sure why noCallThru is even an option to be honest because I always want it on but I'm using es6 and so the api for enabling this can be painful. This is a non-breaking way to support this in es6 code:

## Before
```js
import proxyquire from 'proxyquire'
// proxyquire = proxyquire.noCallThru() // error, proxyquire is read-only
const _proxyquire = proxyquire.noCallThru()
```

## After
```js
import proxyquire from 'proxyquire/nocallthru'
```