### PR TITLE
Do not pollute cache if we load a module via proxyquire before it has ever been loaded before.

### DIFF
--- a/lib/proxyquire.js
+++ b/lib/proxyquire.js
@@ -279,6 +279,8 @@ Proxyquire.prototype._disableModuleCache = function (path, module) {
   return function () {
     if (cached) {
       Module._cache[id] = cached
+    } else {
+      delete Module._cache[id]
     }
   }
 }

--- a/test/proxyquire-cache.js
+++ b/test/proxyquire-cache.js
@@ -17,6 +17,15 @@ describe('Proxyquire', function () {
       assert.equal('cached', foo.state)
       assert.equal(foo, original)
     })
+
+    it('does not pollute the cache when module is proxyquired before it is loaded', function () {
+      var proxyquire = require('..')
+
+      proxyquire('./samples/no-call-thru-test', { './required': false })
+      var original = require('./samples/no-call-thru-test')
+
+      assert.equal(original.original, true)
+    })
   })
 
   describe('preserveCache()', function () {

--- a/test/samples/no-call-thru-test/index.js
+++ b/test/samples/no-call-thru-test/index.js
@@ -1,0 +1,1 @@
+exports.original = require('./required')

--- a/test/samples/no-call-thru-test/required.js
+++ b/test/samples/no-call-thru-test/required.js
@@ -1,0 +1,1 @@
+module.exports = true


### PR DESCRIPTION
Fixes #186.