### PR TITLE
docs: adding patreon badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-# proxyquire [![Build Status](https://secure.travis-ci.org/thlorenz/proxyquire.svg)](http://travis-ci.org/thlorenz/proxyquire)
+# proxyquire [![Build Status](https://secure.travis-ci.org/thlorenz/proxyquire.svg?branch=master)](http://travis-ci.org/thlorenz/proxyquire)
 
-[![NPM](https://nodei.co/npm/proxyquire.png?downloads=true&stars=true)](https://nodei.co/npm/proxyquire/)
+<span>
+  <a href="https://nodei.co/npm/proxyquire/"><img src="https://nodei.co/npm/proxyquire.png?downloads=true&stars=true"></a>
+  <a href="https://www.patreon.com/bePatron?u=8663953"><img alt="become a patron" src="https://c5.patreon.com/external/logo/become_a_patron_button.png" height="69px"></a>
+</span>
 
 Proxies nodejs's require in order to make overriding dependencies during testing easy while staying **totally unobtrusive**.
 


### PR DESCRIPTION
Hoping to get some support from the community with this so I can devote more time to projects like proxyquire.

Note that I put the banners in a span so they could be next to each other, also adapted the _Become a Patron_ image to have same height as the npm pic since otherwise things looked weird.

Also fixed the build status badge to only show results from master.

@bendrucker 