### PR TITLE
Specify ESLint environment for Mocha

### DIFF
--- a/examples/sinon/foo-tests.js
+++ b/examples/sinon/foo-tests.js
@@ -1,7 +1,5 @@
 'use strict'
 
-/* global describe before after it */
-
 /*
  * These examples demonstrate how to use proxyquire with Sinon.JS (<http://sinonjs.org/>).
  * Run these tests with mocha (<http://visionmedia.github.com/mocha/>).

--- a/package.json
+++ b/package.json
@@ -34,5 +34,10 @@
     "fill-keys": "^1.0.2",
     "module-not-found-error": "^1.0.0",
     "resolve": "~1.5.0"
+  },
+  "standard": {
+    "env": [
+      "mocha"
+    ]
   }
 }

--- a/test/proxyquire-api.js
+++ b/test/proxyquire-api.js
@@ -1,7 +1,5 @@
 'use strict'
 
-/* global describe, it */
-
 var assert = require('assert')
 var realFoo = require('./samples/foo')
 

--- a/test/proxyquire-argumentvalidation.js
+++ b/test/proxyquire-argumentvalidation.js
@@ -1,7 +1,5 @@
 'use strict'
 
-/* global describe, it */
-
 var assert = require('assert')
 var proxyquire = require('..')
 

--- a/test/proxyquire-cache.js
+++ b/test/proxyquire-cache.js
@@ -1,7 +1,5 @@
 'use strict'
 
-/* global describe, it */
-
 var assert = require('assert')
 
 describe('Proxyquire', function () {

--- a/test/proxyquire-compat.js
+++ b/test/proxyquire-compat.js
@@ -1,6 +1,5 @@
 'use strict'
 /* jshint asi:true */
-/* global describe, it */
 
 var proxyquire = require('..')
 

--- a/test/proxyquire-extensions.js
+++ b/test/proxyquire-extensions.js
@@ -1,7 +1,5 @@
 'use strict'
 
-/* global describe, before, it */
-
 var proxyquire = require('..').noCallThru()
 
 describe('when I require stubs with different extensions', function () {

--- a/test/proxyquire-global.js
+++ b/test/proxyquire-global.js
@@ -1,7 +1,5 @@
 'use strict'
 
-/* global describe, it */
-
 var assert = require('assert')
 var realFoo = require('./samples/global/foo')
 

--- a/test/proxyquire-independence.js
+++ b/test/proxyquire-independence.js
@@ -1,5 +1,4 @@
 /* jshint asi:true */
-/* global describe, before, it */
 'use strict'
 
 var assert = require('assert')

--- a/test/proxyquire-non-object.js
+++ b/test/proxyquire-non-object.js
@@ -1,7 +1,5 @@
 'use strict'
 
-/* global describe, before, it */
-
 var assert = require('assert')
 var proxyquire = require('..')
 var stats = require('./samples/stats')

--- a/test/proxyquire-notexisting.js
+++ b/test/proxyquire-notexisting.js
@@ -1,7 +1,5 @@
 'use strict'
 
-/* global describe, it */
-
 var assert = require('assert')
 var proxyquire = require('..')
 var path = require('path')

--- a/test/proxyquire-relative-paths.js
+++ b/test/proxyquire-relative-paths.js
@@ -1,7 +1,6 @@
 'use strict'
 
 /* jshint asi:true */
-/* global describe, it */
 
 var proxyquire = require('..')
 

--- a/test/proxyquire-remove.js
+++ b/test/proxyquire-remove.js
@@ -1,6 +1,5 @@
 'use strict'
 /* jshint asi:true */
-/* global describe, it */
 
 var assert = require('assert')
 var proxyquire = require('..')

--- a/test/proxyquire-sub-dependencies.js
+++ b/test/proxyquire-sub-dependencies.js
@@ -1,6 +1,5 @@
 'use strict'
 /* jshint asi:true */
-/* global describe, before, it */
 
 var assert = require('assert')
 var proxyquire = require('..')

--- a/test/proxyquire.js
+++ b/test/proxyquire.js
@@ -1,5 +1,4 @@
 /* jshint asi:true */
-/* global describe, before, beforeEach, it */
 'use strict'
 
 var assert = require('assert')


### PR DESCRIPTION
See [What about Mocha, Jasmine, QUnit, etc?](https://standardjs.com/index.html#what-about-mocha-jasmine-qunit-etc) in JavaScript Standard Style’s FAQ. This is easier than manually specifying globals in every test file.