### PR TITLE
Resolve nonexistent modules via path.resolve with noCallThru()

### DIFF
--- a/lib/proxyquire.js
+++ b/lib/proxyquire.js
@@ -154,7 +154,7 @@ Proxyquire.prototype._resolveModule = function (baseModule, pathToResolve) {
     // directory.  However, if !this._preserveCache, then we don't want to
     // throw, since we can resolve modules that don't exist.  Resolve as
     // best we can.
-    if (!this._preserveCache) {
+    if (!this._preserveCache || this._noCallThru) {
       return path.resolve(path.dirname(baseModule), pathToResolve)
     }
 

--- a/test/proxyquire-notexisting.js
+++ b/test/proxyquire-notexisting.js
@@ -15,13 +15,22 @@ describe('When resolving foo that requires stubbed /not/existing/bar.json', func
   })
 })
 
-describe('When resolving foo that requires stubbed /not/existing/bar.json with noCallThru', function () {
-  var foo
-
+describe('When resolving foo that requires stubbed /not/existing/bar.json with @noCallThru', function () {
   it('resolves foo with stubbed bar', function () {
-    foo = proxyquire(fooPath, {
+    var foo = proxyquire(fooPath, {
       '/not/existing/bar.json': { config: 'bar\'s config', '@noCallThru': true }
     })
     assert.equal(foo.config, 'bar\'s config')
+  })
+})
+
+describe('When resolving foo that requires stubbed /not/existing/bar.json with noCallThru()', function () {
+  it('resolves foo with stubbed bar', function () {
+    proxyquire.noCallThru()
+    var foo = proxyquire(fooPath, {
+      '/not/existing/bar.json': { config: 'bar\'s config' }
+    })
+    assert.equal(foo.config, 'bar\'s config')
+    proxyquire.callThru()
   })
 })


### PR DESCRIPTION
Closes #215

* Existing test covered `@noCallThru`
* Module-wide `noCallThru()` should affect `_require`

@intervalia I'd appreciate if you could try this on your private project. Checked against your repro and `npm test` passes there after `npm install thlorenz/proxyquire#resolve-nonexistent-no-call-thru`.

If that looks ok I'll merge and release.