### PR TITLE
Add throwOnUnresolvedImports method

### DIFF
--- a/lib/proxyquire.js
+++ b/lib/proxyquire.js
@@ -97,6 +97,19 @@ Proxyquire.prototype.preserveCache = function () {
 }
 
 /**
+ * Stubbing a module that does not exist (from the perspective of the proxyquire
+ * subject) will throw an error.
+ * @name throwOnUnresolvedImports
+ * @function
+ * @private
+ * @return {object} The proxyquire function to allow chaining
+ */
+Proxyquire.prototype.throwOnUnresolvedImports = function () {
+  this._throwOnUnresolvedImports = true
+  return this.fn
+}
+
+/**
  * Loads a module using the given stubs instead of their normally resolved required modules.
  * @param request The requirable module path to load.
  * @param stubs The stubs to use. e.g., { "path": { extname: function () { ... } } }
@@ -140,6 +153,10 @@ Proxyquire.prototype._resolveModule = function (baseModule, pathToResolve) {
       paths: Module.globalPaths
     })
   } catch (err) {
+    if (this._throwOnUnresolvedImports) {
+      throw new ProxyquireError('Invalid stub: "' + pathToResolve + '" is not required by the proxyquired object')
+    }
+
     // If this is not a relative path (e.g. "foo" as opposed to "./foo"), and
     // we couldn't resolve it, then we just let the path through unchanged.
     // It's safe to do this, because if two different modules require "foo",

--- a/test/proxyquire-argumentvalidation.js
+++ b/test/proxyquire-argumentvalidation.js
@@ -63,4 +63,18 @@ describe('Illegal parameters to resolve give meaningful errors', function () {
       throws(act, /Invalid stub: "myStub" cannot be undefined/)
     })
   })
+
+  describe('when I pass a stub with a key that is not required on the proxyquired object', function () {
+    function act () {
+      const proxyquireThrowOnUnresolvedImports = proxyquire.throwOnUnresolvedImports()
+
+      proxyquireThrowOnUnresolvedImports('./samples/foo', {
+        nonExistent: () => {}
+      })
+    }
+
+    it('throws an exception with the stub key', function () {
+      throws(act, /Invalid stub: "nonExistent" is not required by the proxyquired object/)
+    })
+  })
 })


### PR DESCRIPTION
Add an optional configuration function, similar in API to noCallThru,
that will force Proxyquire to throw an error if one of the stub keys is
not resolvable. Currently, it silently stubs out a module that is not
utilized by the object being proxyquired.

The intended use case is to aid in refactoring and debugging. Test
suites may optionally enable this feature so that developers get a
meaningful message when they attempt to proxyquire an import that is not
used, as, generally, this is a result of forgetting to update a
proxyquire statement after changing the name or imports of a module.

===

Thanks for all your work on proxyquire - myself and the team I am on have gotten some real use out of it! I have found that additional information when refactoring code would be helpful (i.e., we rename `foobar.js => foobarFunction.js`, forget to update our `proxyquire({ 'foobar': ... })`, and then the proxyquired object calls out to the actual `foobarFunction`, possibly having side effects or just generally making debugging a bit more difficult.

Please let me know if you want any changes to this PR (and no hard feelings if it's not something you want to bring in to the mainline (: ) - thanks!