### PR TITLE
README.md: Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ assert.notEqual(foo1, foo2);
 assert.notEqual(foo1, foo3);
 ```
 
-`require.preserveCache` allows you to restore the behavior to match nodejs's `require` again.
+`proxyquire.preserveCache` allows you to restore the behavior to match nodejs's `require` again.
 
 ```js
 proxyquire.preserveCache();


### PR DESCRIPTION
A sentence says to use `require.preserveCache` above a code example that uses `proxyquire.preserveCache`, so I changed the sentence to match the code