### PR TITLE
Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,16 +44,16 @@ var proxyquire =  require('proxyquire')
 
 // when no overrides are specified, path.extname behaves normally
 var foo = proxyquire('./foo', { 'path': pathStub });
-assert.equal(foo.extnameAllCaps('file.txt'), '.TXT');
+assert.strictEqual(foo.extnameAllCaps('file.txt'), '.TXT');
 
 // override path.extname
 pathStub.extname = function (file) { return 'Exterminate, exterminate the ' + file; };
 
 // path.extname now behaves as we told it to
-assert.equal(foo.extnameAllCaps('file.txt'), 'EXTERMINATE, EXTERMINATE THE FILE.TXT');
+assert.strictEqual(foo.extnameAllCaps('file.txt'), 'EXTERMINATE, EXTERMINATE THE FILE.TXT');
 
 // path.basename and all other path module methods still function as before
-assert.equal(foo.basenameAllCaps('/a/b/file.txt'), 'FILE.TXT');
+assert.strictEqual(foo.basenameAllCaps('/a/b/file.txt'), 'FILE.TXT');
 ```
 
 You can also replace functions directly:
@@ -248,8 +248,8 @@ var foo2 = proxyquire('./foo', stubs);
 var foo3 = require('./foo');
 
 // foo1, foo2 and foo3 are different instances of the same module
-assert.notEqual(foo1, foo2);
-assert.notEqual(foo1, foo3);
+assert.notStrictEqual(foo1, foo2);
+assert.notStrictEqual(foo1, foo3);
 ```
 
 `proxyquire.preserveCache` allows you to restore the behavior to match nodejs's `require` again.
@@ -262,8 +262,8 @@ var foo2 = proxyquire('./foo', stubs);
 var foo3 = require('./foo');
 
 // foo1, foo2 and foo3 are the same instance
-assert.equal(foo1, foo2);
-assert.equal(foo1, foo3);
+assert.strictEqual(foo1, foo2);
+assert.strictEqual(foo1, foo3);
 ```
 
 

--- a/examples/api/api-test.js
+++ b/examples/api/api-test.js
@@ -14,34 +14,34 @@ foo = proxyquire('./samples/foo', { })
 fooCut = proxyquire('./samples/foo', { './bar': cutBarStub })
 fooWild = proxyquire('./samples/foo', { './bar': wildBarStub })
 
-assert.equal(stats.fooRequires(), 3)
+assert.strictEqual(stats.fooRequires(), 3)
 
-assert.equal(foo.bigBar(), 'BAR')
-assert.equal(fooCut.bigBar(), 'BARBER')
-assert.equal(fooWild.bigBar(), 'BARBAR')
+assert.strictEqual(foo.bigBar(), 'BAR')
+assert.strictEqual(fooCut.bigBar(), 'BARBER')
+assert.strictEqual(fooWild.bigBar(), 'BARBAR')
 
 // non overriden keys call thru by default
-assert.equal(foo.bigRab(), 'RAB')
-assert.equal(fooCut.bigRab(), 'RAB')
+assert.strictEqual(foo.bigRab(), 'RAB')
+assert.strictEqual(fooCut.bigRab(), 'RAB')
 
 // non overridden module path untouched
-assert.equal(foo.bigExt(file), '.EXT')
-assert.equal(fooCut.bigExt(file), '.EXT')
-assert.equal(fooWild.bigExt(file), '.EXT')
-assert.equal(foo.bigBas(file), 'TEST.EXT')
-assert.equal(fooCut.bigBas(file), 'TEST.EXT')
-assert.equal(fooWild.bigBas(file), 'TEST.EXT')
+assert.strictEqual(foo.bigExt(file), '.EXT')
+assert.strictEqual(fooCut.bigExt(file), '.EXT')
+assert.strictEqual(fooWild.bigExt(file), '.EXT')
+assert.strictEqual(foo.bigBas(file), 'TEST.EXT')
+assert.strictEqual(fooCut.bigBas(file), 'TEST.EXT')
+assert.strictEqual(fooWild.bigBas(file), 'TEST.EXT')
 
 // overriding keys after require works for both inline and non inline requires
 cutBarStub.bar = function () { return 'friseur' }
 cutBarStub.rab = function () { return 'rabarber' }
 
-assert.equal(fooCut.bigBar(), 'FRISEUR')
-assert.equal(fooCut.bigRab(), 'RABARBER')
+assert.strictEqual(fooCut.bigBar(), 'FRISEUR')
+assert.strictEqual(fooCut.bigRab(), 'RABARBER')
 
 // autofilling keys on delete only works for inline requires
 cutBarStub.bar = undefined
-assert.equal(fooCut.bigBar(), 'BAR')
+assert.strictEqual(fooCut.bigBar(), 'BAR')
 
 cutBarStub.rab = undefined
 assert.throws(fooCut.bigRab)
@@ -54,8 +54,8 @@ foo = proxyquire('./samples/foo', {
   }
 })
 
-assert.equal(foo.bigExt(file), 'EXTERMINATE, EXTERMINATE THE /SOME/PATH/TEST.EXT')
-assert.equal(foo.bigBas(file), 'TEST.EXT')
+assert.strictEqual(foo.bigExt(file), 'EXTERMINATE, EXTERMINATE THE /SOME/PATH/TEST.EXT')
+assert.strictEqual(foo.bigBas(file), 'TEST.EXT')
 
 // turned off
 foo = proxyquire('./samples/foo', {
@@ -65,7 +65,7 @@ foo = proxyquire('./samples/foo', {
   }
 })
 
-assert.equal(foo.bigExt(file), 'EXTERMINATE, EXTERMINATE THE /SOME/PATH/TEST.EXT')
+assert.strictEqual(foo.bigExt(file), 'EXTERMINATE, EXTERMINATE THE /SOME/PATH/TEST.EXT')
 assert.throws(foo.bigBas)
 
 // turned off globally
@@ -92,7 +92,7 @@ foo = proxyquire
     }
   })
 
-assert.equal(foo.bigBas(file), 'TEST.EXT')
+assert.strictEqual(foo.bigBas(file), 'TEST.EXT')
 
 // turned back on globally
 
@@ -104,7 +104,7 @@ foo = proxyquire
     }
   })
 
-assert.equal(foo.bigBas(file), 'TEST.EXT')
+assert.strictEqual(foo.bigBas(file), 'TEST.EXT')
 
 // turned back off per module
 

--- a/examples/async/foo-tests.js
+++ b/examples/async/foo-tests.js
@@ -18,13 +18,13 @@ var foo = proxyquire('./foo', { fs: fsStub })
 /*
 * Test caps locking of returned files
 */
-fsStub.readdir = function (dir, cb) { cb(null, [ 'file1', 'file2' ]) }
+fsStub.readdir = function (dir, cb) { cb(null, ['file1', 'file2']) }
 
 calledBack = false
 foo.filesAllCaps('./somedir', function (err, files) {
-  assert.equal(err, null)
-  assert.equal(files[0], 'FILE1')
-  assert.equal(files[1], 'FILE2')
+  assert.strictEqual(err, null)
+  assert.strictEqual(files[0], 'FILE1')
+  assert.strictEqual(files[1], 'FILE2')
 
   calledBack = true
 })
@@ -38,7 +38,7 @@ assert(calledBack)
 fsStub.readdir = function (dir, cb) { cb(readdirError) }
 
 foo.filesAllCaps('./somedir', function (err, files) {
-  assert.equal(err, readdirError)
+  assert.strictEqual(err, readdirError)
 })
 
 console.log('*** All asserts passed ***')

--- a/examples/simple/foo.inlineoverride.test.js
+++ b/examples/simple/foo.inlineoverride.test.js
@@ -10,7 +10,7 @@ var foo
 
 // no overrides yet, so path.extname behaves normally
 foo = proxyquire('./foo', {})
-assert.equal(foo.extnameAllCaps('file.txt'), '.TXT')
+assert.strictEqual(foo.extnameAllCaps('file.txt'), '.TXT')
 
 // override path.extname
 foo = proxyquire('./foo', {
@@ -18,9 +18,9 @@ foo = proxyquire('./foo', {
 })
 
 // path.extname now behaves as we told it to
-assert.equal(foo.extnameAllCaps('file.txt'), 'EXTERMINATE, EXTERMINATE THE FILE.TXT')
+assert.strictEqual(foo.extnameAllCaps('file.txt'), 'EXTERMINATE, EXTERMINATE THE FILE.TXT')
 
 // path.basename on the other hand still functions as before
-assert.equal(foo.basenameAllCaps('/a/b/file.txt'), 'FILE.TXT')
+assert.strictEqual(foo.basenameAllCaps('/a/b/file.txt'), 'FILE.TXT')
 
 console.log('*** All asserts passed ***')

--- a/examples/simple/foo.test.js
+++ b/examples/simple/foo.test.js
@@ -9,16 +9,16 @@ var assert = require('assert')
 var pathStub = { }
 
 // when not overridden, path.extname behaves normally
-var foo = proxyquire('./foo', { 'path': pathStub })
-assert.equal(foo.extnameAllCaps('file.txt'), '.TXT')
+var foo = proxyquire('./foo', { path: pathStub })
+assert.strictEqual(foo.extnameAllCaps('file.txt'), '.TXT')
 
 // override path.extname
 pathStub.extname = function (file) { return 'Exterminate, exterminate the ' + file }
 
 // path.extname now behaves as we told it to
-assert.equal(foo.extnameAllCaps('file.txt'), 'EXTERMINATE, EXTERMINATE THE FILE.TXT')
+assert.strictEqual(foo.extnameAllCaps('file.txt'), 'EXTERMINATE, EXTERMINATE THE FILE.TXT')
 
 // path.basename and all other path module methods still function as before
-assert.equal(foo.basenameAllCaps('/a/b/file.txt'), 'FILE.TXT')
+assert.strictEqual(foo.basenameAllCaps('/a/b/file.txt'), 'FILE.TXT')
 
 console.log('*** All asserts passed ***')

--- a/examples/sinon/foo-tests.js
+++ b/examples/sinon/foo-tests.js
@@ -30,7 +30,7 @@ describe('when path.extname(file) returns ".markdown"', function () {
   })
 
   it('extnameAllCaps returns ".MARKDOWN"', function () {
-    assert.equal(foo.extnameAllCaps(file), '.MARKDOWN')
+    assert.strictEqual(foo.extnameAllCaps(file), '.MARKDOWN')
   })
 })
 
@@ -42,7 +42,7 @@ describe('when fs.readdir calls back with ["file1", "file2"]', function () {
     readdirStub = sinon.stub(fs, 'readdir')
     foo = proxyquire('./foo', { fs: { readdir: readdirStub } })
 
-    readdirStub.withArgs('../simple').yields(null, [ 'file1', 'file2' ])
+    readdirStub.withArgs('../simple').yields(null, ['file1', 'file2'])
   })
 
   after(function () {
@@ -51,9 +51,9 @@ describe('when fs.readdir calls back with ["file1", "file2"]', function () {
 
   it('filesAllCaps calls back with ["FILE1", "FILE2"]', function (done) {
     foo.filesAllCaps('../simple', function (err, files) {
-      assert.equal(err, null)
-      assert.equal(files[0], 'FILE1')
-      assert.equal(files[1], 'FILE2')
+      assert.strictEqual(err, null)
+      assert.strictEqual(files[0], 'FILE1')
+      assert.strictEqual(files[1], 'FILE2')
       done()
     })
   })
@@ -77,8 +77,8 @@ describe('when fs.readdir returns an error', function () {
 
   it('filesAllCaps calls back with that error', function (done) {
     foo.filesAllCaps('../simple', function (err, files) {
-      assert.equal(err, readdirError)
-      assert.equal(files, null)
+      assert.strictEqual(err, readdirError)
+      assert.strictEqual(files, null)
       done()
     })
   })
@@ -101,7 +101,7 @@ describe('when calling filesAllCaps with "../simple"', function () {
     foo.filesAllCaps('../simple', function (err, files) {
       assert.ifError(err)
       assert(fs.readdir.calledOnce)
-      assert.equal(fs.readdir.getCall(0).args[0], '../simple')
+      assert.strictEqual(fs.readdir.getCall(0).args[0], '../simple')
       done()
     })
   })

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   "devDependencies": {
     "mocha": "^6.1.4",
     "native-hello-world": "^1.0.0",
-    "standard": "^11.0.0"
     "should": "^13.2.3",
     "sinon": "^7.3.2",
+    "standard": "^13.0.1"
   },
   "dependencies": {
     "fill-keys": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "Thorsten Lorenz",
   "license": "MIT",
   "devDependencies": {
-    "mocha": "^6.1.4",
+    "mocha": "^5.2.0",
     "native-hello-world": "^1.0.0",
     "should": "^13.2.3",
     "sinon": "^7.3.2",

--- a/package.json
+++ b/package.json
@@ -24,16 +24,16 @@
   "author": "Thorsten Lorenz",
   "license": "MIT",
   "devDependencies": {
-    "mocha": "^5.2.0",
+    "mocha": "^6.1.4",
     "native-hello-world": "^1.0.0",
-    "should": "~13.2",
-    "sinon": "~6.1",
     "standard": "^11.0.0"
+    "should": "^13.2.3",
+    "sinon": "^7.3.2",
   },
   "dependencies": {
     "fill-keys": "^1.0.2",
-    "module-not-found-error": "^1.0.0",
-    "resolve": "~1.8.1"
+    "module-not-found-error": "^1.0.1",
+    "resolve": "^1.11.1"
   },
   "standard": {
     "env": [

--- a/test/proxyquire-api.js
+++ b/test/proxyquire-api.js
@@ -17,21 +17,21 @@ describe('api', function () {
     it('proxyquire can load', function () {
       var proxiedFoo = proxyquire.load('./samples/foo', stubs)
 
-      assert.equal(typeof proxiedFoo, 'object')
+      assert.strictEqual(typeof proxiedFoo, 'object')
       assert.notStrictEqual(realFoo, proxiedFoo)
     })
 
     it('proxyquire can callThru and then load', function () {
       var proxiedFoo = proxyquire.callThru().load('./samples/foo', stubs)
 
-      assert.equal(typeof proxiedFoo, 'object')
+      assert.strictEqual(typeof proxiedFoo, 'object')
       assert.notStrictEqual(realFoo, proxiedFoo)
     })
 
     it('proxyquire can noCallThru and then load', function () {
       var proxiedFoo = proxyquire.noCallThru().load('./samples/foo', stubs)
 
-      assert.equal(typeof proxiedFoo, 'object')
+      assert.strictEqual(typeof proxiedFoo, 'object')
       assert.notStrictEqual(realFoo, proxiedFoo)
     })
   })

--- a/test/proxyquire-cache.js
+++ b/test/proxyquire-cache.js
@@ -9,11 +9,11 @@ describe('Proxyquire', function () {
       original.state = 'cached'
 
       var proxyquire = require('..')
-      proxyquire('./samples/foo', { 'path': { } })
+      proxyquire('./samples/foo', { path: { } })
 
       var foo = require('./samples/foo')
-      assert.equal('cached', foo.state)
-      assert.equal(foo, original)
+      assert.strictEqual('cached', foo.state)
+      assert.strictEqual(foo, original)
     })
 
     it('does not pollute the cache when module is proxyquired before it is loaded', function () {
@@ -22,14 +22,14 @@ describe('Proxyquire', function () {
       proxyquire('./samples/no-call-thru-test', { './required': false })
       var original = require('./samples/no-call-thru-test')
 
-      assert.equal(original.original, true)
+      assert.strictEqual(original.original, true)
     })
   })
 
   describe('preserveCache()', function () {
     it('returns a reference to itself, so it can be chained', function () {
       var proxyquire = require('..')
-      assert.equal(proxyquire.preserveCache(), proxyquire)
+      assert.strictEqual(proxyquire.preserveCache(), proxyquire)
     })
 
     it('has Proxyquire restore the cache for the module', function () {
@@ -38,11 +38,11 @@ describe('Proxyquire', function () {
 
       var proxyquire = require('..')
       proxyquire.preserveCache()
-      proxyquire.load('./samples/foo', { 'path': { } })
+      proxyquire.load('./samples/foo', { path: { } })
 
       var foo = require('./samples/foo')
-      assert.equal('cached', foo.state)
-      assert.equal(foo, original)
+      assert.strictEqual('cached', foo.state)
+      assert.strictEqual(foo, original)
     })
 
     it('allows Singletons to function properly', function () {
@@ -50,17 +50,17 @@ describe('Proxyquire', function () {
 
       var proxyquire = require('..')
       proxyquire.preserveCache()
-      proxyquire.load('./samples/foo-singleton', { 'path': { } }).getInstance()
+      proxyquire.load('./samples/foo-singleton', { path: { } }).getInstance()
 
       var fooSingleton = require('./samples/foo-singleton').getInstance()
-      assert.equal(fooSingleton, original)
+      assert.strictEqual(fooSingleton, original)
     })
   })
 
   describe('noPreserveCache()', function () {
     it('returns a reference to itself, so it can be chained', function () {
       var proxyquire = require('..')
-      assert.equal(proxyquire.noPreserveCache(), proxyquire)
+      assert.strictEqual(proxyquire.noPreserveCache(), proxyquire)
     })
 
     it('forces subsequent requires to reload the proxied module', function () {
@@ -68,24 +68,24 @@ describe('Proxyquire', function () {
       original.state = 'cached'
 
       var proxyquire = require('..')
-      proxyquire.load('./samples/foo', { 'path': { } })
+      proxyquire.load('./samples/foo', { path: { } })
 
       var cacheFoo = require('./samples/foo')
-      assert.equal('cached', cacheFoo.state)
-      assert.equal(cacheFoo, original)
+      assert.strictEqual('cached', cacheFoo.state)
+      assert.strictEqual(cacheFoo, original)
 
       proxyquire.noPreserveCache()
-      proxyquire.load('./samples/foo', { 'path': { } })
+      proxyquire.load('./samples/foo', { path: { } })
       var foo = require('./samples/foo')
-      assert.equal('', foo.state)
-      assert.notEqual(foo, original)
+      assert.strictEqual('', foo.state)
+      assert.notStrictEqual(foo, original)
     })
 
     it('deletes the require.cache for the module being stubbed', function () {
       var proxyquire = require('..').noPreserveCache()
 
-      proxyquire.load('./samples/foo', { 'path': { } })
-      assert.equal(undefined, require.cache[require.resolve('./samples/foo')])
+      proxyquire.load('./samples/foo', { path: { } })
+      assert.strictEqual(undefined, require.cache[require.resolve('./samples/foo')])
     })
 
     it('deletes the require.cache for the stubs', function () {
@@ -96,15 +96,15 @@ describe('Proxyquire', function () {
       bar.f.g = function () { return 'a' }
       bar.h = function () { return 'a' }
 
-      assert.equal(foo.bar.f.g(), 'a')
-      assert.equal(foo.bar.h(), 'a')
+      assert.strictEqual(foo.bar.f.g(), 'a')
+      assert.strictEqual(foo.bar.h(), 'a')
 
       foo = proxyquire.load('./samples/cache/foo', { './bar': {} })
-      assert.equal(foo.bar.h(), 'h')
-      assert.equal(foo.bar.f.g(), 'g')
+      assert.strictEqual(foo.bar.h(), 'h')
+      assert.strictEqual(foo.bar.f.g(), 'g')
 
-      assert.equal(undefined, require.cache[require.resolve('./samples/cache/foo')])
-      assert.equal(undefined, require.cache[require.resolve('./samples/cache/bar')])
+      assert.strictEqual(undefined, require.cache[require.resolve('./samples/cache/foo')])
+      assert.strictEqual(undefined, require.cache[require.resolve('./samples/cache/bar')])
     })
 
     it('silences errors when stub lookups fail', function () {

--- a/test/proxyquire-global.js
+++ b/test/proxyquire-global.js
@@ -18,8 +18,8 @@ describe('global flags set', function () {
 
     var proxiedFoo = proxyquire('./samples/global/foo', stubs)
 
-    assert.equal(realFoo(), false)
-    assert.equal(proxiedFoo(), true)
+    assert.strictEqual(realFoo(), false)
+    assert.strictEqual(proxiedFoo(), true)
   })
 
   it('should override require globally even when require\'s execution is deferred', function () {
@@ -34,13 +34,13 @@ describe('global flags set', function () {
 
     var proxiedFoo = proxyquire('./samples/global/foo-deferred', stubs)
 
-    assert.equal(realFoo(), false)
-    assert.equal(proxiedFoo(), true)
+    assert.strictEqual(realFoo(), false)
+    assert.strictEqual(proxiedFoo(), true)
   })
 
   it('should not throw when a native module is required a second time', function () {
     var stubs = {
-      'foo': {
+      foo: {
         '@global': true
       }
     }
@@ -62,8 +62,8 @@ describe('global flags not set', function () {
 
     var proxiedFoo = proxyquire('./samples/global/foo', stubs)
 
-    assert.equal(realFoo(), false)
-    assert.equal(proxiedFoo(), false)
+    assert.strictEqual(realFoo(), false)
+    assert.strictEqual(proxiedFoo(), false)
   })
 
   it('should not override require globally even when require\'s execution is deferred', function () {
@@ -77,7 +77,7 @@ describe('global flags not set', function () {
 
     var proxiedFoo = proxyquire('./samples/global/foo-deferred', stubs)
 
-    assert.equal(realFoo(), false)
-    assert.equal(proxiedFoo(), false)
+    assert.strictEqual(realFoo(), false)
+    assert.strictEqual(proxiedFoo(), false)
   })
 })

--- a/test/proxyquire-independence.js
+++ b/test/proxyquire-independence.js
@@ -17,11 +17,11 @@ describe('Multiple requires of same module don\'t affect each other', function (
     })
 
     it('foo1.bigBar() == "BAR1"', function () {
-      assert.equal(foo1.bigBar(), 'BAR1')
+      assert.strictEqual(foo1.bigBar(), 'BAR1')
     })
 
     it('foo2.bigBar() == "BAR2"', function () {
-      assert.equal(foo2.bigBar(), 'BAR2')
+      assert.strictEqual(foo2.bigBar(), 'BAR2')
     })
 
     describe('and I change bar1.bar() to return barone', function () {
@@ -30,11 +30,11 @@ describe('Multiple requires of same module don\'t affect each other', function (
       })
 
       it('foo1.bigBar() == "BARONE"', function () {
-        assert.equal(foo1.bigBar(), 'BARONE')
+        assert.strictEqual(foo1.bigBar(), 'BARONE')
       })
 
       it('foo2.bigBar() == "BAR2"', function () {
-        assert.equal(foo2.bigBar(), 'BAR2')
+        assert.strictEqual(foo2.bigBar(), 'BAR2')
       })
     })
   })

--- a/test/proxyquire-non-object.js
+++ b/test/proxyquire-non-object.js
@@ -14,16 +14,16 @@ describe('Given foo requires the boof, foonum and foobool modules and  boof is a
   describe('When I resolve foo with boofber stub as boof.', function () {
     before(function () {
       stats.reset()
-      foo = proxyquire('./samples/foo', {'./boof': boofber})
+      foo = proxyquire('./samples/foo', { './boof': boofber })
     })
 
     it('foo is required 1 times', function () {
-      assert.equal(stats.fooRequires(), 1)
+      assert.strictEqual(stats.fooRequires(), 1)
     })
 
     describe('foo\'s boof is boofber', function () {
       it('foo.boof == boofber', function () {
-        assert.equal(foo.boof, boofber)
+        assert.strictEqual(foo.boof, boofber)
       })
     })
   })
@@ -31,16 +31,16 @@ describe('Given foo requires the boof, foonum and foobool modules and  boof is a
   describe('When I resolve foo with foonumber stub as foonum.', function () {
     before(function () {
       stats.reset()
-      foo = proxyquire('./samples/foo', {'./foonum': foonumber})
+      foo = proxyquire('./samples/foo', { './foonum': foonumber })
     })
 
     it('foo is required 1 times', function () {
-      assert.equal(stats.fooRequires(), 1)
+      assert.strictEqual(stats.fooRequires(), 1)
     })
 
     describe('foo\'s foonum is foonumber', function () {
       it('foo.foonum == foonumber', function () {
-        assert.equal(foo.foonum, foonumber)
+        assert.strictEqual(foo.foonum, foonumber)
       })
     })
   })
@@ -48,16 +48,16 @@ describe('Given foo requires the boof, foonum and foobool modules and  boof is a
   describe('When I resolve foo with fooboolber stub as foobool.', function () {
     before(function () {
       stats.reset()
-      foo = proxyquire('./samples/foo', {'./foobool': fooboolber})
+      foo = proxyquire('./samples/foo', { './foobool': fooboolber })
     })
 
     it('foo is required 1 times', function () {
-      assert.equal(stats.fooRequires(), 1)
+      assert.strictEqual(stats.fooRequires(), 1)
     })
 
     describe('foo\'s foobool is fooboolber', function () {
       it('foo.foobool == fooboolber', function () {
-        assert.equal(foo.foobool, fooboolber)
+        assert.strictEqual(foo.foobool, fooboolber)
       })
     })
   })
@@ -65,16 +65,16 @@ describe('Given foo requires the boof, foonum and foobool modules and  boof is a
   describe('When I resolve foo with ./fooarray stub as fooarray.', function () {
     before(function () {
       stats.reset()
-      foo = proxyquire('./samples/foo', {'./fooarray': fooarray})
+      foo = proxyquire('./samples/foo', { './fooarray': fooarray })
     })
 
     it('foo is required 1 times', function () {
-      assert.equal(stats.fooRequires(), 1)
+      assert.strictEqual(stats.fooRequires(), 1)
     })
 
     describe('foo\'s fooarray is fooarray', function () {
       it('foo.fooarray is fooarray', function () {
-        assert.deepEqual(foo.fooarray, ['x', 'y', 'z'])
+        assert.deepStrictEqual(foo.fooarray, ['x', 'y', 'z'])
       })
     })
   })
@@ -82,16 +82,16 @@ describe('Given foo requires the boof, foonum and foobool modules and  boof is a
   describe('When I resolve foo with ./fooarray stub as empty.', function () {
     before(function () {
       stats.reset()
-      foo = proxyquire('./samples/foo', {'./fooarray': []})
+      foo = proxyquire('./samples/foo', { './fooarray': [] })
     })
 
     it('foo is required 1 times', function () {
-      assert.equal(stats.fooRequires(), 1)
+      assert.strictEqual(stats.fooRequires(), 1)
     })
 
     describe('foo\'s fooarray is the original', function () {
       it('foo.fooarray is empty', function () {
-        assert.deepEqual(foo.fooarray, ['a', 'b', 'c'])
+        assert.deepStrictEqual(foo.fooarray, ['a', 'b', 'c'])
       })
     })
   })
@@ -100,17 +100,17 @@ describe('Given foo requires the boof, foonum and foobool modules and  boof is a
     before(function () {
       stats.reset()
       var empty = []
-      Object.defineProperty(empty, '@noCallThru', {value: true})
-      foo = proxyquire('./samples/foo', {'./fooarray': empty})
+      Object.defineProperty(empty, '@noCallThru', { value: true })
+      foo = proxyquire('./samples/foo', { './fooarray': empty })
     })
 
     it('foo is required 1 times', function () {
-      assert.equal(stats.fooRequires(), 1)
+      assert.strictEqual(stats.fooRequires(), 1)
     })
 
     describe('foo\'s fooarray is empty', function () {
       it('foo.fooarray is empty', function () {
-        assert.deepEqual(foo.fooarray, [])
+        assert.deepStrictEqual(foo.fooarray, [])
       })
     })
   })

--- a/test/proxyquire-notexisting.js
+++ b/test/proxyquire-notexisting.js
@@ -20,7 +20,7 @@ describe('When resolving foo that requires stubbed /not/existing/bar.json with @
     var foo = proxyquire(fooPath, {
       '/not/existing/bar.json': { config: 'bar\'s config', '@noCallThru': true }
     })
-    assert.equal(foo.config, 'bar\'s config')
+    assert.strictEqual(foo.config, 'bar\'s config')
   })
 })
 
@@ -30,7 +30,7 @@ describe('When resolving foo that requires stubbed /not/existing/bar.json with n
     var foo = proxyquire(fooPath, {
       '/not/existing/bar.json': { config: 'bar\'s config' }
     })
-    assert.equal(foo.config, 'bar\'s config')
+    assert.strictEqual(foo.config, 'bar\'s config')
     proxyquire.callThru()
   })
 })

--- a/test/proxyquire-relative-paths.js
+++ b/test/proxyquire-relative-paths.js
@@ -6,7 +6,7 @@ var proxyquire = require('..')
 
 describe('When requiring relative paths, they should be relative to the proxyrequired module', function () {
   it('should return the correct result', function () {
-    var result = proxyquire('./samples/relative-paths/a/index.js', {'./util': {c: 'c'}})
-    result.should.eql({a: 'a', c: 'c'})
+    var result = proxyquire('./samples/relative-paths/a/index.js', { './util': { c: 'c' } })
+    result.should.eql({ a: 'a', c: 'c' })
   })
 })

--- a/test/proxyquire-remove.js
+++ b/test/proxyquire-remove.js
@@ -17,6 +17,6 @@ describe('When resolving foo that requires nulled file package', function () {
 describe('When resolving foo that optionally requires nulled crypto package', function () {
   it('catches when resolving crypto', function () {
     var foo = proxyquire(fooPath, { crypto: null })
-    assert.equal(foo.bigCrypto(), 'caught')
+    assert.strictEqual(foo.bigCrypto(), 'caught')
   })
 })

--- a/test/proxyquire-sub-dependencies.js
+++ b/test/proxyquire-sub-dependencies.js
@@ -22,10 +22,10 @@ describe('When resolving foo that requires bar and stubbed baz where bar require
   })
 
   it('does not stub baz in bar', function () {
-    assert.equal(foo.bar.baz.testexport, 'test')
+    assert.strictEqual(foo.bar.baz.testexport, 'test')
   })
 
   it('does not affect a normal baz import', function () {
-    assert.equal(baz.testexport, 'test')
+    assert.strictEqual(baz.testexport, 'test')
   })
 })

--- a/test/proxyquire.js
+++ b/test/proxyquire.js
@@ -19,26 +19,26 @@ describe('Given foo requires the bar and path modules and bar.bar() returns "bar
     })
 
     it('foo is required 2 times', function () {
-      assert.equal(stats.fooRequires(), 2)
+      assert.strictEqual(stats.fooRequires(), 2)
     })
 
     describe('foo\'s bar is unchanged', function () {
       it('foo.bigBar() == "BAR"', function () {
-        assert.equal(foo.bigBar(), 'BAR')
+        assert.strictEqual(foo.bigBar(), 'BAR')
       })
     })
 
     describe('only stubbed modules have overrides in foober', function () {
       it('foober.bigBar() == "BARBER"', function () {
-        assert.equal(foober.bigBar(), 'BARBER')
+        assert.strictEqual(foober.bigBar(), 'BARBER')
       })
 
       it('foober.bigExt("/folder/test.ext") == ".EXT"', function () {
-        assert.equal(foober.bigExt(file), '.EXT')
+        assert.strictEqual(foober.bigExt(file), '.EXT')
       })
 
       it('foober.bigBas("/folder/test.ext") == "TEST.EXT"', function () {
-        assert.equal(foober.bigBas(file), 'TEST.EXT')
+        assert.strictEqual(foober.bigBas(file), 'TEST.EXT')
       })
     })
 
@@ -49,11 +49,11 @@ describe('Given foo requires the bar and path modules and bar.bar() returns "bar
       })
 
       it('overrides behavior when module is required inside function call', function () {
-        assert.equal(foober.bigBar(), 'FRISEUR')
+        assert.strictEqual(foober.bigBar(), 'FRISEUR')
       })
 
       it('overrides behavior when module is required on top of file', function () {
-        assert.equal(foober.bigRab(), 'RABARBER')
+        assert.strictEqual(foober.bigRab(), 'RABARBER')
       })
 
       describe('and then delete overrides of stubs after resolve', function () {
@@ -63,7 +63,7 @@ describe('Given foo requires the bar and path modules and bar.bar() returns "bar
         })
 
         it('reverts to original behavior when module is required inside function call', function () {
-          assert.equal(foober.bigBar(), 'BAR')
+          assert.strictEqual(foober.bigBar(), 'BAR')
         })
 
         it('doesn\'t properly revert to original behavior when module is required on top of file ', function () {
@@ -85,11 +85,11 @@ describe('Given foo requires the bar and path modules and bar.bar() returns "bar
         })
 
         it('foo.bigExt(file) == "OVERRIDE /FOLDER/TEST.EXT"', function () {
-          assert.equal(foo.bigExt(file), 'OVERRIDE /FOLDER/TEST.EXT')
+          assert.strictEqual(foo.bigExt(file), 'OVERRIDE /FOLDER/TEST.EXT')
         })
 
         it('foo.bigBas(file) == "TEST.EXT"', function () {
-          assert.equal(foo.bigBas(file), 'TEST.EXT')
+          assert.strictEqual(foo.bigBas(file), 'TEST.EXT')
         })
       })
 
@@ -103,7 +103,7 @@ describe('Given foo requires the bar and path modules and bar.bar() returns "bar
         })
 
         it('foo.bigExt(file) == "OVERRIDE /FOLDER/TEST.EXT"', function () {
-          assert.equal(foo.bigExt(file), 'OVERRIDE /FOLDER/TEST.EXT')
+          assert.strictEqual(foo.bigExt(file), 'OVERRIDE /FOLDER/TEST.EXT')
         })
 
         it('foo.bigBas(file) throws', function () {
@@ -127,7 +127,7 @@ describe('Given foo requires the bar and path modules and bar.bar() returns "bar
           })
 
           it('foo.bigExt(file) == "OVERRIDE /FOLDER/TEST.EXT"', function () {
-            assert.equal(foo.bigExt(file), 'OVERRIDE /FOLDER/TEST.EXT')
+            assert.strictEqual(foo.bigExt(file), 'OVERRIDE /FOLDER/TEST.EXT')
           })
 
           it('foo.bigBas(file) throws', function () {
@@ -145,11 +145,11 @@ describe('Given foo requires the bar and path modules and bar.bar() returns "bar
           })
 
           it('foo.bigExt(file) == "OVERRIDE /FOLDER/TEST.EXT"', function () {
-            assert.equal(foo.bigExt(file), 'OVERRIDE /FOLDER/TEST.EXT')
+            assert.strictEqual(foo.bigExt(file), 'OVERRIDE /FOLDER/TEST.EXT')
           })
 
           it('foo.bigBas(file) == "TEST.EXT"', function () {
-            assert.equal(foo.bigBas(file), 'TEST.EXT')
+            assert.strictEqual(foo.bigBas(file), 'TEST.EXT')
           })
         })
 
@@ -165,11 +165,11 @@ describe('Given foo requires the bar and path modules and bar.bar() returns "bar
           })
 
           it('foo.bigExt(file) == "OVERRIDE /FOLDER/TEST.EXT"', function () {
-            assert.equal(foo.bigExt(file), 'OVERRIDE /FOLDER/TEST.EXT')
+            assert.strictEqual(foo.bigExt(file), 'OVERRIDE /FOLDER/TEST.EXT')
           })
 
           it('foo.bigBas(file) == "TEST.EXT"', function () {
-            assert.equal(foo.bigBas(file), 'TEST.EXT')
+            assert.strictEqual(foo.bigBas(file), 'TEST.EXT')
           })
         })
       })

--- a/test/samples/cache/foo.js
+++ b/test/samples/cache/foo.js
@@ -1,3 +1,3 @@
 var bar = require('./bar')
 
-module.exports = {bar: bar}
+module.exports = { bar: bar }


### PR DESCRIPTION
Hello! 👋 
This PR updates dependencies to their latest version.
The update to standard is isolated in its own commit (`5a30adc`).

As a bonus, we saw a great performance improvement from using resolve@1.11.1 in a code base making heavy use of proxyquire:

* proxyquire@1: 0m12.708s
* proxyquire@2: 1m31.892s
* proxyquire@2 (with updated deps): 0m32.991s