### PR TITLE
Fix removal of module with null throwing incorrect error type

### DIFF
--- a/lib/proxyquire.js
+++ b/lib/proxyquire.js
@@ -154,18 +154,14 @@ Proxyquire.prototype._resolveModule = function (baseModule, pathToResolve, stubs
     // directory.  However, if !this._preserveCache, then we don't want to
     // throw, since we can resolve modules that don't exist.  Resolve as
     // best we can. We also need to check if the relative module has @noCallThru.
+    var resolvedPath = path.resolve(path.dirname(baseModule), pathToResolve)
     var moduleNoCallThru
-    var resolvedPath
-    if (hasOwnProperty.call(stubs, pathToResolve)) {
+    if (hasOwnProperty.call(stubs, pathToResolve) && stubs[pathToResolve]) {
       // pathToResolve is currently relative on stubs from _withoutCache() call
       moduleNoCallThru = hasOwnProperty.call(stubs[pathToResolve], '@noCallThru') ? stubs[pathToResolve]['@noCallThru'] : undefined
-      resolvedPath = path.resolve(path.dirname(baseModule), pathToResolve)
-    } else {
-      resolvedPath = path.resolve(path.dirname(baseModule), pathToResolve)
-      if (hasOwnProperty.call(stubs, resolvedPath)) {
-        // after _withoutCache() alters stubs paths to be absolute
-        moduleNoCallThru = hasOwnProperty.call(stubs[resolvedPath], '@noCallThru') ? stubs[resolvedPath]['@noCallThru'] : undefined
-      }
+    } else if (hasOwnProperty.call(stubs, resolvedPath) && stubs[resolvedPath]) {
+      // after _withoutCache() alters stubs paths to be absolute
+      moduleNoCallThru = hasOwnProperty.call(stubs[resolvedPath], '@noCallThru') ? stubs[resolvedPath]['@noCallThru'] : undefined
     }
     if (!this._preserveCache || this._noCallThru || moduleNoCallThru) {
       return resolvedPath

--- a/test/proxyquire-remove.js
+++ b/test/proxyquire-remove.js
@@ -10,6 +10,8 @@ describe('When resolving foo that requires nulled file package', function () {
   it('throws an error', function () {
     assert.throws(function () {
       proxyquire(fooPath, { path: null })
+    }, function (error) {
+      return error.code === 'MODULE_NOT_FOUND'
     })
   })
 })


### PR DESCRIPTION
0297d28 did not properly handle `null` as a stub, so instead of throwing a `MODULE_NOT_FOUND` error, proxyquire would throw a `TypeError`. This PR fixes the `_resolveModule` function and updates the test to detect this in the future.