### PR TITLE
docs: Fix simple typo, overriden -> overridden

### DIFF
--- a/examples/api/api-test.js
+++ b/examples/api/api-test.js
@@ -20,7 +20,7 @@ assert.strictEqual(foo.bigBar(), 'BAR')
 assert.strictEqual(fooCut.bigBar(), 'BARBER')
 assert.strictEqual(fooWild.bigBar(), 'BARBAR')
 
-// non overriden keys call thru by default
+// non overridden keys call thru by default
 assert.strictEqual(foo.bigRab(), 'RAB')
 assert.strictEqual(fooCut.bigRab(), 'RAB')
 


### PR DESCRIPTION
There is a small typo in examples/api/api-test.js.

Should read `overridden` rather than `overriden`.

