### PR TITLE
Cleanup temporal module from a cache, fixes #174

### DIFF
--- a/lib/proxyquire.js
+++ b/lib/proxyquire.js
@@ -284,6 +284,13 @@ Proxyquire.prototype._disableModuleCache = function (path, module) {
 
   // Return a function that will undo what we just did
   return function () {
+    const currentModule = Module._cache[id];
+    const currentModuleParent = currentModule.parent;
+     // remove reference to a temporal module from a parent
+    if (currentModuleParent && currentModuleParent.children) {
+      currentModuleParent.children = currentModuleParent.children.filter(m => m !== currentModule)
+    }
+    // restore cache entry
     if (cached) {
       Module._cache[id] = cached
     } else {


### PR DESCRIPTION
Resolves #174 by removing reference to a newly created module from a parent module.
Both the current module and the parent modules are expected to exist by the definition of this operation.